### PR TITLE
fix: inconsistent height size in android devices

### DIFF
--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
-import { StyleSheet, View, useWindowDimensions } from 'react-native';
+import { Dimensions, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import BottomSheetNativeComponent from './BottomSheetNativeComponent';
@@ -89,7 +89,7 @@ export const BottomSheet = ({
   scrimColor,
   scrimOpacities,
 }: BottomSheetProps) => {
-  const { height: windowHeight } = useWindowDimensions();
+  const { height: windowHeight } = Dimensions.get('screen');
   const insets = useSafeAreaInsets();
   const maxHeight = windowHeight - insets.top;
   const nativeDetents = detents.map((detent) => {

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -1,7 +1,10 @@
 import { useState, type ComponentType, type ReactNode } from 'react';
 import type { NativeSyntheticEvent, StyleProp, ViewStyle } from 'react-native';
-import { Dimensions, StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StyleSheet, View } from 'react-native';
+import {
+  useSafeAreaFrame,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 
 import BottomSheetNativeView, {
   type NativeProps,
@@ -122,7 +125,7 @@ export const BottomSheet = ({
   scrimColor,
   scrimOpacities,
 }: BottomSheetProps) => {
-  const { height: windowHeight } = Dimensions.get('screen');
+  const { height: windowHeight } = useSafeAreaFrame();
   const insets = useSafeAreaInsets();
   const maxHeight = windowHeight - insets.top;
   const nativeDetents = detents.map((detent) => {


### PR DESCRIPTION
The `useWindowDimensions`  hook returns incosistent window height (there is a open issue [41918](https://github.com/facebook/react-native/issues/41918)), On some android devices the top inset is included in the returned `heigth` value,  and therefore  the top inset is calculated twice.

<img  height="600" alt="Screenshot 2026-06-01 at 14 41 55" src="https://github.com/user-attachments/assets/c2a32473-bcd9-436e-ad07-897907d8aa67" />

## Fix
Replaced `useWindowDimensions` with `useSafeAreaFrame`
<img height="600" alt="Screenshot 2026-06-01 at 14 42 16" src="https://github.com/user-attachments/assets/08b5d342-fcf5-4495-bf39-9a9a22d02534" />


