### PR TITLE
feat: add a fractional detent `index` to `onPositionChange`

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,12 @@ drag snapping but can still be targeted via `index`&nbsp;updates.
 
 Use `onPositionChange` to observe the sheet’s current position. It is a standard
 native event; read the distance in pixels from the bottom of the screen to the
-top of the sheet from&nbsp;`event.nativeEvent.position`.
+top of the sheet from&nbsp;`event.nativeEvent.position`. The same event also
+carries `event.nativeEvent.index`—the fractional detent index in
+`0..(detents.length - 1)` (`0` at the shortest detent, `1` at the next, and so
+on, interpolated in between)—the continuous counterpart of `onIndexChange`,
+handy for driving a backdrop or per-detent animation without knowing the
+sheet’s height.
 
 ```tsx
 <BottomSheet // Or `ModalBottomSheet`.
@@ -311,7 +316,7 @@ top of the sheet from&nbsp;`event.nativeEvent.position`.
   onIndexChange={setIndex}
   surface={/* ... */}
   onPositionChange={(event) => {
-    console.log(event.nativeEvent.position);
+    console.log(event.nativeEvent.position, event.nativeEvent.index);
   }}
 >
   {/* ... */}
@@ -356,6 +361,7 @@ import {
 
 ```tsx
 const position = useSharedValue(0);
+const detentIndex = useSharedValue(0);
 
 const onPositionChange = useEvent<
   NativeSyntheticEvent<PositionChangeEventData>
@@ -363,6 +369,7 @@ const onPositionChange = useEvent<
   (event) => {
     'worklet';
     position.value = event.position;
+    detentIndex.value = event.index;
   },
   ['onPositionChange']
 );

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
@@ -35,7 +35,7 @@ interface BottomSheetViewListener {
 
   fun onSettle(index: Int)
 
-  fun onPositionChange(position: Double)
+  fun onPositionChange(position: Double, index: Double)
 }
 
 class BottomSheetView(context: Context) : ReactViewGroup(context) {
@@ -484,9 +484,16 @@ class BottomSheetView(context: Context) : ReactViewGroup(context) {
     updateScrim(position)
     updateSheetVisibility(position)
     updateInteractionState()
-    listener?.onPositionChange((position / density).toDouble())
+    listener?.onPositionChange((position / density).toDouble(), detentIndexAt(position).toDouble())
     updateShadowState(ty)
   }
+
+  // Fractional detent index in 0..(detentSpecs.size - 1): 0 at the shortest
+  // detent, 1 at the next, and so on, interpolated by position in between. The
+  // continuous counterpart of `onIndexChange`, so consumers can drive a backdrop
+  // or animate per detent without knowing the sheet's height.
+  private fun detentIndexAt(position: Float): Float =
+    interpolateAtPosition(position, detentSpecs.indices.map { it.toFloat() })
 
   private fun updateSheetVisibility(position: Float) {
     sheetContainer.alpha = if (position <= 0.5f) 0f else 1f
@@ -911,15 +918,20 @@ class BottomSheetView(context: Context) : ReactViewGroup(context) {
    * Interpolates the scrim opacity for a sheet height by bracketing it between adjacent detent
    * heights and lerping each detent index's configured value.
    */
-  private fun scrimOpacityAt(position: Float): Float {
+  private fun scrimOpacityAt(position: Float): Float =
+    interpolateAtPosition(
+      position,
+      detentSpecs.indices.map {
+        scrimOpacities[it.coerceAtMost(scrimOpacities.size - 1)].coerceIn(0f, 1f)
+      },
+    )
+
+  // Interpolates a per-detent value (one per detent, by index) by the sheet
+  // position, using each detent's resolved height as the breakpoint.
+  private fun interpolateAtPosition(position: Float, values: List<Float>): Float {
     if (detentSpecs.isEmpty()) return 0f
     val pairs =
-      detentSpecs.indices
-        .map { index ->
-          detentSpecs[index].height to
-            scrimOpacities[index.coerceAtMost(scrimOpacities.size - 1)].coerceIn(0f, 1f)
-        }
-        .sortedBy { it.first }
+      detentSpecs.indices.map { detentSpecs[it].height to values[it] }.sortedBy { it.first }
 
     val first = pairs.first()
     val last = pairs.last()

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetViewManager.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetViewManager.kt
@@ -44,8 +44,12 @@ class BottomSheetViewManager :
           dispatchEvent(view, "topSettle", event)
         }
 
-        override fun onPositionChange(position: Double) {
-          val event = Arguments.createMap().apply { putDouble("position", position) }
+        override fun onPositionChange(position: Double, index: Double) {
+          val event =
+            Arguments.createMap().apply {
+              putDouble("position", position)
+              putDouble("index", index)
+            }
           dispatchEvent(view, "topPositionChange", event)
         }
       }

--- a/example/src/demoReanimated.tsx
+++ b/example/src/demoReanimated.tsx
@@ -30,6 +30,10 @@ export const UIThreadPositionScreen = () => {
   // round-trip, so it stays in sync with the sheet even during a fast drag.
   const position = useSharedValue(0);
 
+  // The same event also carries `index`: a fractional detent index, so the UI
+  // can track which detent the sheet is heading toward without knowing heights.
+  const detentIndex = useSharedValue(0);
+
   // Parameterized with the prop's event type, so the handler is assignable with
   // no cast. Reanimated still unwraps `nativeEvent` for the worklet body, so we
   // read `event.position` directly.
@@ -39,19 +43,31 @@ export const UIThreadPositionScreen = () => {
     (event) => {
       'worklet';
       position.value = event.position;
+      detentIndex.value = event.index;
     },
     ['onPositionChange']
   );
 
-  // A read-out updated from the UI thread by animating a TextInput's text.
+  // A read-out animating a TextInput's text from the UI thread.
   const readoutProps = useAnimatedProps(() => ({
     text: `${Math.round(position.value)} pt`,
+    defaultValue: '',
+  }));
+
+  // A second read-out for the fractional detent index from `index`.
+  const detentIndexReadoutProps = useAnimatedProps(() => ({
+    text: `detent ${detentIndex.value.toFixed(2)}`,
     defaultValue: '',
   }));
 
   // A progress bar whose width tracks the sheet height in real time.
   const barStyle = useAnimatedStyle(() => ({
     width: `${Math.min(1, position.value / MAX_POSITION) * 100}%`,
+  }));
+
+  // The same bar, driven off `index` normalized across the detent range.
+  const detentIndexBarStyle = useAnimatedStyle(() => ({
+    width: `${(detentIndex.value / (DETENTS.length - 1)) * 100}%`,
   }));
 
   // A marker pinned to the bottom that rides the sheet's top edge upward.
@@ -105,6 +121,21 @@ export const UIThreadPositionScreen = () => {
         />
         <View style={styles.track}>
           <Animated.View style={[styles.fill, barStyle]} />
+        </View>
+      </View>
+      <View style={styles.card}>
+        <Text style={styles.cardLabel}>
+          Detent index / progress (UI thread)
+        </Text>
+        <AnimatedTextInput
+          editable={false}
+          value={undefined}
+          animatedProps={detentIndexReadoutProps}
+          style={styles.readout}
+        />
+        <Text style={styles.hint}>detent index 0 → {DETENTS.length - 1}</Text>
+        <View style={styles.track}>
+          <Animated.View style={[styles.fill, detentIndexBarStyle]} />
         </View>
       </View>
       <Text style={styles.hint}>

--- a/example/src/demoReanimatedModal.tsx
+++ b/example/src/demoReanimatedModal.tsx
@@ -26,12 +26,17 @@ export const UIThreadModalPositionScreen = () => {
   const [index, setIndex] = useState(1);
   const position = useSharedValue(0);
 
+  // The same event also carries `index`: a fractional detent index, so the UI
+  // can track which detent the sheet is heading toward without knowing heights.
+  const detentIndex = useSharedValue(0);
+
   const onPositionChange = useEvent<
     NativeSyntheticEvent<PositionChangeEventData>
   >(
     (event) => {
       'worklet';
       position.value = event.position;
+      detentIndex.value = event.index;
     },
     ['onPositionChange']
   );
@@ -39,6 +44,17 @@ export const UIThreadModalPositionScreen = () => {
   const readoutProps = useAnimatedProps(() => ({
     text: `${Math.round(position.value)} pt`,
     defaultValue: '',
+  }));
+
+  // A second read-out for the fractional detent index from `index`.
+  const detentIndexReadoutProps = useAnimatedProps(() => ({
+    text: `detent ${detentIndex.value.toFixed(2)}`,
+    defaultValue: '',
+  }));
+
+  // A bar driven off `index` normalized across the detent range.
+  const detentIndexBarStyle = useAnimatedStyle(() => ({
+    width: `${(detentIndex.value / (DETENTS.length - 1)) * 100}%`,
   }));
 
   // A blue circle that rides the modal sheet's top edge on the UI thread.
@@ -94,6 +110,21 @@ export const UIThreadModalPositionScreen = () => {
         />
         <Text style={styles.hint}>max detent: {MAX_POSITION}pt</Text>
       </View>
+      <View style={styles.card}>
+        <Text style={styles.cardLabel}>
+          Detent index / progress (UI thread)
+        </Text>
+        <AnimatedTextInput
+          editable={false}
+          value={undefined}
+          animatedProps={detentIndexReadoutProps}
+          style={styles.readout}
+        />
+        <Text style={styles.hint}>detent index 0 → {DETENTS.length - 1}</Text>
+        <View style={styles.track}>
+          <Animated.View style={[styles.fill, detentIndexBarStyle]} />
+        </View>
+      </View>
     </DemoScreen>
   );
 };
@@ -111,6 +142,17 @@ const styles = StyleSheet.create({
   cardLabel: { fontWeight: '600', color: '#1f1f1f' },
   hint: { color: '#555' },
   readout: { fontSize: 36, fontWeight: '700', color: '#1f1f1f', padding: 0 },
+  track: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#ddd',
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: 4,
+    backgroundColor: '#3b82f6',
+  },
   circleAnchor: {
     position: 'absolute',
     left: 0,

--- a/ios/BottomSheetComponentView.mm
+++ b/ios/BottomSheetComponentView.mm
@@ -140,11 +140,14 @@ using namespace facebook::react;
   }
 }
 
-- (void)bottomSheetView:(BottomSheetContentView *)view didChangePosition:(CGFloat)position
+- (void)bottomSheetView:(BottomSheetContentView *)view
+      didChangePosition:(CGFloat)position
+                  index:(CGFloat)index
 {
   if (_eventEmitter) {
     auto emitter = std::static_pointer_cast<const BottomSheetViewEventEmitter>(_eventEmitter);
-    emitter->onPositionChange({.position = static_cast<double>(position)});
+    emitter->onPositionChange(
+        {.position = static_cast<double>(position), .index = static_cast<double>(index)});
   }
 
   float contentOffsetY = static_cast<float>(view.currentContentOffsetY);

--- a/ios/BottomSheetContentView.h
+++ b/ios/BottomSheetContentView.h
@@ -7,7 +7,9 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol BottomSheetContentViewDelegate <NSObject>
 - (void)bottomSheetView:(BottomSheetContentView *)view didChangeIndex:(NSInteger)index;
 - (void)bottomSheetView:(BottomSheetContentView *)view didSettle:(NSInteger)index;
-- (void)bottomSheetView:(BottomSheetContentView *)view didChangePosition:(CGFloat)position;
+- (void)bottomSheetView:(BottomSheetContentView *)view
+      didChangePosition:(CGFloat)position
+                  index:(CGFloat)index;
 - (void)bottomSheetView:(BottomSheetContentView *)view didReportError:(NSString *)message;
 @end
 

--- a/ios/BottomSheetContentView.mm
+++ b/ios/BottomSheetContentView.mm
@@ -125,9 +125,11 @@
   [self.delegate bottomSheetView:self didSettle:index];
 }
 
-- (void)bottomSheetHostingView:(BottomSheetHostingView *)view didChangePosition:(CGFloat)position
+- (void)bottomSheetHostingView:(BottomSheetHostingView *)view
+              didChangePosition:(CGFloat)position
+                          index:(CGFloat)index
 {
-  [self.delegate bottomSheetView:self didChangePosition:position];
+  [self.delegate bottomSheetView:self didChangePosition:position index:index];
 }
 
 - (void)bottomSheetHostingView:(BottomSheetHostingView *)view didReportError:(NSString *)message

--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -3,7 +3,8 @@ import UIKit
 @objc public protocol BottomSheetHostingViewDelegate: AnyObject {
   func bottomSheetHostingView(_ view: BottomSheetHostingView, didChangeIndex index: Int)
   func bottomSheetHostingView(_ view: BottomSheetHostingView, didSettle index: Int)
-  func bottomSheetHostingView(_ view: BottomSheetHostingView, didChangePosition position: CGFloat)
+  func bottomSheetHostingView(
+    _ view: BottomSheetHostingView, didChangePosition position: CGFloat, index: CGFloat)
   func bottomSheetHostingView(_ view: BottomSheetHostingView, didReportError message: String)
 }
 
@@ -357,7 +358,8 @@ public final class BottomSheetHostingView: UIView {
     updateScrim(forPosition: position)
     updateSheetVisibility(forPosition: position)
     updateInteractionState()
-    eventDelegate?.bottomSheetHostingView(self, didChangePosition: position)
+    eventDelegate?.bottomSheetHostingView(
+      self, didChangePosition: position, index: detentIndex(forPosition: position))
   }
 
   private func startDisplayLink() {
@@ -899,26 +901,40 @@ private extension BottomSheetHostingView {
   /// Interpolates the scrim opacity for a sheet height by bracketing it between
   /// adjacent detent heights and lerping each detent index's configured value.
   private func scrimOpacity(forPosition position: CGFloat) -> CGFloat {
-    guard !detentSpecs.isEmpty else { return 0 }
-    let pairs = detentSpecs.indices
-      .map { (
-        height: detentSpecs[$0].height,
-        opacity: clampOpacity(scrimOpacities[min($0, scrimOpacities.count - 1)])
-      ) }
+    interpolate(
+      forPosition: position,
+      values: detentSpecs.indices.map {
+        clampOpacity(scrimOpacities[min($0, scrimOpacities.count - 1)])
+      })
+  }
+
+  // Fractional detent index in 0...(detentSpecs.count - 1): 0 at the shortest
+  // detent, 1 at the next, and so on, interpolated by position in between. The
+  // continuous counterpart of `onIndexChange`, so consumers can drive a backdrop
+  // or animate per detent without knowing the sheet's height.
+  private func detentIndex(forPosition position: CGFloat) -> CGFloat {
+    interpolate(forPosition: position, values: detentSpecs.indices.map { CGFloat($0) })
+  }
+
+  // Interpolates a per-detent value (one per detent, by index) by the sheet
+  // position, using each detent's resolved height as the breakpoint.
+  private func interpolate(forPosition position: CGFloat, values: [CGFloat]) -> CGFloat {
+    let pairs = zip(detentSpecs.map(\.height), values)
+      .map { (height: $0, value: $1) }
       .sorted { $0.height < $1.height }
 
     guard let first = pairs.first, let last = pairs.last else { return 0 }
-    if position <= first.height { return first.opacity }
-    if position >= last.height { return last.opacity }
+    if position <= first.height { return first.value }
+    if position >= last.height { return last.value }
 
     for i in 1 ..< pairs.count where position <= pairs[i].height {
       let lower = pairs[i - 1]
       let upper = pairs[i]
       let span = upper.height - lower.height
       let t = span <= 0 ? 1 : (position - lower.height) / span
-      return lower.opacity + (upper.opacity - lower.opacity) * t
+      return lower.value + (upper.value - lower.value) * t
     }
-    return last.opacity
+    return last.value
   }
 
   private func clampOpacity(_ value: CGFloat) -> CGFloat {

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -19,6 +19,13 @@ export { programmatic } from './bottomSheetUtils';
 export type PositionChangeEventData = Readonly<{
   /** Sheet position, in points from the bottom. */
   position: number;
+  /**
+   * Fractional detent index in `0..(detents.length - 1)`: `0` at the shortest
+   * detent, `1` at the next, and so on, interpolated as the sheet moves between
+   * them. The continuous counterpart of `onIndexChange`, so a backdrop or
+   * per-detent animation can be driven without knowing the sheet's height.
+   */
+  index: number;
 }>;
 
 /**

--- a/src/BottomSheetNativeComponent.ts
+++ b/src/BottomSheetNativeComponent.ts
@@ -27,7 +27,7 @@ export interface NativeProps extends ViewProps {
     Readonly<{ index: CodegenTypes.Int32 }>
   >;
   onPositionChange?: CodegenTypes.DirectEventHandler<
-    Readonly<{ position: CodegenTypes.Double }>
+    Readonly<{ position: CodegenTypes.Double; index: CodegenTypes.Double }>
   >;
 }
 


### PR DESCRIPTION
## Summary

Adds a continuous `index` value to the `onPositionChange` event.

Today, `onPositionChange` only exposes the sheet's `position` (distance from the bottom). While this is sufficient for many use cases, deriving the sheet's progress between detents requires consumers to manually calculate it from detent heights. This becomes particularly difficult when using the `'content'` detent, whose height is not available on the JS side.

With this change, the event now includes:

```ts
{
  position: number;
  index: number;
}
```

The new `index` value represents the sheet's current detent index as a continuous value:

- `0` = first detent
- `1` = second detent
- `2` = third detent
- `2.5` = halfway between the third and fourth detent

You can think of it as the animated equivalent of `onIndexChange`.

## Motivation

This enables use cases that require a normalized "open progress" value without needing to know the underlying detent heights.

Examples:

### Shared backdrop across stacked sheets

The built-in scrim is scoped to an individual sheet. In applications that manage multiple stacked sheets with a single shared backdrop, consumers need a way to determine how open the top sheet is.

```ts
animatedIndex = event.index - 1;
```

can then be used directly to drive backdrop opacity.

### Animating content behind the sheet

Consumers can smoothly animate the underlying screen (e.g. dimming, scaling, blurring) based on sheet progress between detents without hardcoding pixel values or tracking detent heights.

## Implementation

The continuous index is computed natively on both iOS and Android using the same interpolation logic already used internally by the scrim animation. The shared calculation has been extracted into a small helper and the resulting value is emitted alongside `position`.

This change is fully backward compatible and does not modify existing behavior.

## Examples

The inline and modal examples have been updated to read and display the new `index` value.

## Testing

Tested in the example application (New Architecture):

- iOS (iPhone 17 Pro)
- Android (Pixel 9 Pro)

For detents `[120, 360, 600]`, the emitted values progress continuously from `0 → 1 → 2`.

For modal detents `[0, 360, 600]`, the closed state correctly reports `index = 0`.