### PR TITLE
fix(ios): request high refresh rate for the sheet display link

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -365,6 +365,10 @@ public final class BottomSheetHostingView: UIView {
   private func startDisplayLink() {
     guard displayLink == nil else { return }
     let link = CADisplayLink(target: self, selector: #selector(displayLinkFired))
+    // Drive the spring at the display's high refresh rate. Without an explicit
+    // range a CADisplayLink runs at 60fps on ProMotion (even with
+    // CADisableMinimumFrameDurationOnPhone set), so the sheet animates at 60fps.
+    link.preferredFrameRateRange = CAFrameRateRange(minimum: 80, maximum: 120, preferred: 120)
     link.add(to: .main, forMode: .common)
     displayLink = link
   }


### PR DESCRIPTION
### What

The open/close spring is driven by a `CADisplayLink` in `startDisplayLink()`, but the link never sets `preferredFrameRateRange`. On ProMotion devices a `CADisplayLink` defaults to 60fps even when the app has `CADisableMinimumFrameDurationOnPhone` enabled, so the sheet animates at 60fps while Reanimated-driven content on the same screen runs at 120fps. Side by side the difference in smoothness is clearly visible.

### Fix

Request the display's high refresh rate on the link:

```swift
link.preferredFrameRateRange = CAFrameRateRange(minimum: 80, maximum: 120, preferred: 120)
```

### Notes

- It's a hint, not a guarantee — the system still throttles under Low Power Mode and thermal pressure.
- No-op for apps that haven't opted into high refresh (no `CADisableMinimumFrameDurationOnPhone`) and on 60Hz devices, so there's no regression risk.
- Tested on an iPhone 16 Pro: open/close now runs at 120fps, matching the Reanimated-based sheets.
