### PR TITLE
feat: add disable dismiss on scrim press to native scrim

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ const insets = useSafeAreaInsets();
 
 #### Scrim
 
-Tapping the scrim collapses the sheet. Use `scrimColor` to customize
+Tapping the scrim collapses the sheet. Pass `disableDismissOnScrimPress` to keep
+the sheet open when the native scrim is pressed. Use `scrimColor` to customize
 its&nbsp;color:
 
 ```tsx

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -67,6 +67,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
     }
 
   var disableScrollableNegotiation: Boolean = false
+  var disableDismissOnScrimPress: Boolean = false
   private var pendingIndex: Int? = null
   private var hasLaidOut = false
   private var isPanning = false
@@ -101,7 +102,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private var surfaceView: View? = null
 
   private val contentHeightMarkerLayoutListener =
-    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
+    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+      refreshDetentsFromLayout()
+    }
 
   init {
     clipChildren = false
@@ -233,17 +236,16 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   // MARK: - Prop setters
 
   fun setDetents(raw: List<Map<String, Any>>) {
-    rawDetentSpecs =
-      raw.mapNotNull { dict ->
-        val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
-        val kind =
-          when ((dict["kind"] as? String)?.lowercase()) {
-            "content" -> DetentKind.CONTENT
-            else -> DetentKind.POINTS
-          }
-        val programmatic = dict["programmatic"] as? Boolean ?: false
-        RawDetentSpec(value = (value * density).toFloat(), kind = kind, programmatic = programmatic)
-      }
+    rawDetentSpecs = raw.mapNotNull { dict ->
+      val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
+      val kind =
+        when ((dict["kind"] as? String)?.lowercase()) {
+          "content" -> DetentKind.CONTENT
+          else -> DetentKind.POINTS
+        }
+      val programmatic = dict["programmatic"] as? Boolean ?: false
+      RawDetentSpec(value = (value * density).toFloat(), kind = kind, programmatic = programmatic)
+    }
     refreshDetentsFromLayout()
   }
 
@@ -709,7 +711,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
         }
         MotionEvent.ACTION_UP -> {
           val closeIndex = closedIndex
-          val shouldDismiss = scrimPressed && isScrimVisible()
+          val shouldDismiss = scrimPressed && isScrimVisible() && !disableDismissOnScrimPress
           scrimPressed = false
           scrimTouchActive = false
           activePointerId = MotionEvent.INVALID_POINTER_ID

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
@@ -130,6 +130,12 @@ class BottomSheetView(context: Context) : ReactViewGroup(context), LifecycleEven
       host.disableScrollableNegotiation = value
     }
 
+  var disableDismissOnScrimPress: Boolean
+    get() = host.disableDismissOnScrimPress
+    set(value) {
+      host.disableDismissOnScrimPress = value
+    }
+
   fun setScrimColor(color: Int?) = host.setScrimColor(color)
 
   fun setScrimOpacities(values: List<Float>) = host.setScrimOpacities(values)
@@ -280,15 +286,14 @@ class BottomSheetView(context: Context) : ReactViewGroup(context), LifecycleEven
 
     WindowCompat.setDecorFitsSystemWindows(this, false)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-      attributes =
-        attributes.apply {
-          layoutInDisplayCutoutMode =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-              WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
-            } else {
-              WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-            }
-        }
+      attributes = attributes.apply {
+        layoutInDisplayCutoutMode =
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+          } else {
+            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+          }
+      }
     }
 
     @Suppress("DEPRECATION")

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetViewManager.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetViewManager.kt
@@ -149,6 +149,11 @@ class BottomSheetViewManager :
     view.disableScrollableNegotiation = value
   }
 
+  @ReactProp(name = "disableDismissOnScrimPress")
+  override fun setDisableDismissOnScrimPress(view: BottomSheetView, value: Boolean) {
+    view.disableDismissOnScrimPress = value
+  }
+
   @ReactProp(name = "scrimColor", customType = "Color")
   override fun setScrimColor(view: BottomSheetView, scrimColor: Int?) {
     view.setScrimColor(scrimColor)

--- a/ios/BottomSheetComponentView.mm
+++ b/ios/BottomSheetComponentView.mm
@@ -130,6 +130,10 @@ using namespace facebook::react;
     _sheetView.disableScrollableNegotiation = newViewProps.disableScrollableNegotiation;
   }
 
+  if (newViewProps.disableDismissOnScrimPress != oldViewProps.disableDismissOnScrimPress) {
+    _sheetView.disableDismissOnScrimPress = newViewProps.disableDismissOnScrimPress;
+  }
+
   if (newViewProps.scrimColor != oldViewProps.scrimColor) {
     [_sheetView setScrimColor:RCTUIColorFromSharedColor(newViewProps.scrimColor)];
   }

--- a/ios/BottomSheetContentView.h
+++ b/ios/BottomSheetContentView.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL animateContentHeight;
 @property (nonatomic) BOOL modal;
 @property (nonatomic) BOOL disableScrollableNegotiation;
+@property (nonatomic) BOOL disableDismissOnScrimPress;
 @property (nonatomic, readonly) UIView *sheetContainer;
 @property (nonatomic, readonly) BOOL isModalAccessibilityActive;
 

--- a/ios/BottomSheetContentView.mm
+++ b/ios/BottomSheetContentView.mm
@@ -60,6 +60,16 @@
   _impl.disableScrollableNegotiation = disableScrollableNegotiation;
 }
 
+- (BOOL)disableDismissOnScrimPress
+{
+  return _impl.disableDismissOnScrimPress;
+}
+
+- (void)setDisableDismissOnScrimPress:(BOOL)disableDismissOnScrimPress
+{
+  _impl.disableDismissOnScrimPress = disableDismissOnScrimPress;
+}
+
 - (BOOL)modal
 {
   return _impl.modal;

--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -53,6 +53,7 @@ public final class BottomSheetHostingView: UIView {
   }
 
   public var disableScrollableNegotiation: Bool = false
+  public var disableDismissOnScrimPress: Bool = false
 
   private var rawDetentSpecs: [RawDetentSpec] = []
   private var detentSpecs: [DetentSpec] = [] {
@@ -415,6 +416,7 @@ public final class BottomSheetHostingView: UIView {
   @objc private func handleScrimPress() {
     guard
       modal,
+      !disableDismissOnScrimPress,
       let closedIndex,
       targetIndex != closedIndex,
       activeSpring == nil || currentSheetHeight > 0.5

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -124,6 +124,8 @@ type ModalOnlyBottomSheetProps = {
    * instead of the `BottomSheetProvider` portal.
    */
   nativeOverlay?: boolean;
+  /** Disable dismissing the modal sheet when pressing the native scrim. */
+  disableDismissOnScrimPress?: boolean;
   /** Scrim color used by `ModalBottomSheet`. */
   scrimColor?: string;
   /**
@@ -163,6 +165,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
     modal = false,
     nativeOverlay = false,
     disableScrollableNegotiation = false,
+    disableDismissOnScrimPress = false,
     scrimColor,
     scrimOpacities,
   } = props as BottomSheetInternalProps;
@@ -252,6 +255,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
           modal={modal}
           nativeOverlay={usesNativeOverlay}
           disableScrollableNegotiation={disableScrollableNegotiation}
+          disableDismissOnScrimPress={disableDismissOnScrimPress}
           scrimColor={scrimColor}
           scrimOpacities={resolvedScrimOpacity}
           onIndexChange={handleIndexChange}

--- a/src/BottomSheetNativeComponent.ts
+++ b/src/BottomSheetNativeComponent.ts
@@ -20,6 +20,7 @@ export interface NativeProps extends ViewProps {
   modal: boolean;
   nativeOverlay?: boolean;
   disableScrollableNegotiation?: boolean;
+  disableDismissOnScrimPress?: boolean;
   scrimColor?: ColorValue;
   scrimOpacities?: ReadonlyArray<CodegenTypes.Double>;
   onIndexChange?: CodegenTypes.DirectEventHandler<

--- a/src/ModalBottomSheet.tsx
+++ b/src/ModalBottomSheet.tsx
@@ -29,6 +29,12 @@ export interface ModalBottomSheetProps extends BottomSheetProps {
   /** Scrim color shown behind the modal sheet. */
   scrimColor?: string;
   /**
+   * Whether pressing the native scrim should leave the sheet open.
+   *
+   * @default false
+   */
+  disableDismissOnScrimPress?: boolean;
+  /**
    * Scrim opacities per detent, indexed to match `detents`. Each value in 0-1
    * scales the scrim color's alpha at the detent of the same index, and the
    * opacity is linearly interpolated as the sheet is dragged between detents.


### PR DESCRIPTION
## Summary
Add an option to disable dismiss on native scrim press.

## Motivation
Sometimes we need the modal to be dissmissed only by an internal action like a confirm/next button, currently to do this, we need to create a custom scrim, this pr enables this feature in the built-in scrim along with the use of 
`detents={[programmatic(0), 'content']}`
