### PR TITLE
Avoid detached-layer begin time for iOS sheet animation

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -480,7 +480,7 @@ public final class BottomSheetHostingView: UIView {
     }
     animation.duration = duration
     animation.calculationMode = .linear
-    animation.beginTime = sheetContainer.layer.convertTime(startTime, from: nil)
+    animation.beginTime = 0
     animation.isRemovedOnCompletion = false
     animation.fillMode = .forwards
     animation.delegate = self


### PR DESCRIPTION
## Summary

This is the smaller of two possible fixes for an iOS animation glitch where a `ModalBottomSheet` can briefly render at its final open position before its opening animation starts.

The issue was reproducible after navigating to a screen with a `TextInput autoFocus`, going back, and then opening a modal sheet. Native traces showed the snap animation being added while the hosting view was temporarily detached (`window == nil`). Because the model transform is set to the target before adding the keyframe animation, a delayed animation start can render the fully-open model layer for a few frames.

This patch lets Core Animation start the keyframe animation at transaction commit time by using `beginTime = 0`.

## Notes

This fixes the observed blink in the repro, but it slightly changes the original timing model: the render-server animation starts at Core Animation commit time while the display-link `CriticalSpring` is still anchored to the `CACurrentMediaTime()` sampled in `snapToIndex`.

I am also opening a second draft PR with a more conservative fix that defers detached snaps until the view is attached and keeps the explicit synchronized begin time.

## Validation

Validated in a local Expo SDK 56 / React Native 0.85.3 repro app:

- Original code + `TextInput autoFocus`: sheet flashes fully open, then jumps down and animates.
- This patch + `TextInput autoFocus`: presentation layer animates continuously from closed to open.
- TypeScript check in the repro app: `npx tsc --noEmit`.

Representative fixed trace:

```text
frame=1 presentationTy=812
frame=2 presentationTy=799
frame=3 presentationTy=761
frame=4 presentationTy=710
```
