### PR TITLE
Defer iOS sheet snaps until attached

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -24,6 +24,14 @@ private struct RawDetentSpec {
   let programmatic: Bool
 }
 
+private struct PendingSnapRequest {
+  let index: Int
+  let velocity: CGFloat
+  let emitIndexChange: Bool
+  let emitSettle: Bool
+  let preserveScrimPin: Bool
+}
+
 @objcMembers
 public final class BottomSheetHostingView: UIView {
   public weak var eventDelegate: BottomSheetHostingViewDelegate?
@@ -75,6 +83,7 @@ public final class BottomSheetHostingView: UIView {
   private var scrimPinnedFull = false
   private var displayLink: CADisplayLink?
   private var pendingIndex: Int?
+  private var pendingSnapRequest: PendingSnapRequest?
   private var hasLaidOut = false
   private var isPanning = false
   private var lastReportedInvalidDetentMessage: String?
@@ -132,11 +141,13 @@ public final class BottomSheetHostingView: UIView {
       for gr in view.gestureRecognizers ?? [] {
         if NSStringFromClass(type(of: gr)).contains("TouchHandler") {
           surfaceTouchHandler = gr
-          return
+          break
         }
       }
+      if surfaceTouchHandler != nil { break }
       current = view.superview
     }
+    flushPendingSnapIfNeeded()
   }
 
   override public func layoutSubviews() {
@@ -288,6 +299,7 @@ public final class BottomSheetHostingView: UIView {
     detentSpecs = []
     targetIndex = 0
     pendingIndex = nil
+    pendingSnapRequest = nil
     hasLaidOut = false
     isPanning = false
     panStartingIndex = nil
@@ -433,6 +445,19 @@ public final class BottomSheetHostingView: UIView {
     preserveScrimPin: Bool = false
   ) {
     guard index >= 0, index < detentSpecs.count else { return }
+    if window == nil, activeSpring == nil {
+      // Avoid starting a render-server animation before the layer is attached:
+      // UIKit may briefly display the model transform before keyframes begin.
+      pendingSnapRequest = PendingSnapRequest(
+        index: index,
+        velocity: velocity,
+        emitIndexChange: emitIndexChange,
+        emitSettle: emitSettle,
+        preserveScrimPin: preserveScrimPin
+      )
+      return
+    }
+
     targetIndex = index
     if !preserveScrimPin {
       scrimPinnedFull = false
@@ -497,6 +522,18 @@ public final class BottomSheetHostingView: UIView {
     if emitIndexChange {
       eventDelegate?.bottomSheetHostingView(self, didChangeIndex: index)
     }
+  }
+
+  private func flushPendingSnapIfNeeded() {
+    guard window != nil, let request = pendingSnapRequest else { return }
+    pendingSnapRequest = nil
+    snapToIndex(
+      request.index,
+      velocity: request.velocity,
+      emitIndexChange: request.emitIndexChange,
+      emitSettle: request.emitSettle,
+      preserveScrimPin: request.preserveScrimPin
+    )
   }
 
   private func stepSpring(targetTime: CFTimeInterval) {


### PR DESCRIPTION
## Summary

This is the more conservative of two possible fixes for an iOS animation glitch where a `ModalBottomSheet` can briefly render at its final open position before its opening animation starts.

The issue was reproducible after navigating to a screen with a `TextInput autoFocus`, going back, and then opening a modal sheet. Native traces showed the open snap being requested while the hosting view was temporarily detached (`window == nil`). Because `snapToIndex` sets the model transform to the target before adding the keyframe animation, UIKit/Core Animation can briefly display the final model transform before the keyframes begin.

This patch defers snaps requested while detached, then flushes them in `didMoveToWindow` once `window != nil`. The actual keyframe animation still uses the existing explicit layer-local `beginTime`, preserving the intended synchronization between the render-server animation and the display-link `CriticalSpring` position updates.

## Related alternative

I also opened a smaller draft workaround in #27 that changes the keyframe animation to `beginTime = 0`. That avoids the flash, but slightly weakens the original clock-sync model. This PR keeps that model intact by avoiding detached-layer animation starts instead.

## Validation

Validated in a local Expo SDK 56 / React Native 0.85.3 repro app:

- Original code + `TextInput autoFocus`: sheet flashes fully open, then jumps down and animates.
- This patch + `TextInput autoFocus`: snap is deferred while `window == nil`, flushed when attached, and the sheet animates continuously from closed to open.
- This patch + direct modal open from a fresh home screen: snap also defers briefly during portal attachment and animates continuously.
- TypeScript check in the repro app: `npx tsc --noEmit`.

Representative fixed trace from the autofocus repro:

```text
snapToIndex.deferred window=nil index=1
snapToIndex.flushDeferred window=UIWindow index=1
snap.prepare target=1 window=UIWindow currentTy=812 targetTy=312
snap.afterAddAnimation target=1 window=UIWindow beginTime=<layer time>
frame=1 presentationTy=812 springTy=808
frame=2 presentationTy=779 springTy=779
frame=3 presentationTy=732 springTy=732
frame=4 presentationTy=679 springTy=679
```
