### PR TITLE
fix: disable scrim dismissal when the closed detent is programmatic-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ const insets = useSafeAreaInsets();
 
 #### Scrim
 
-Tapping the scrim collapses the sheet. Use `scrimColor` to customize
-its&nbsp;color:
+Tapping the scrim collapses the sheet when the closed detent is user-reachable.
+If the closed detent is `programmatic(0)`, scrim press stays disabled. Use
+`scrimColor` to customize its&nbsp;color:
 
 ```tsx
 <ModalBottomSheet
@@ -353,7 +354,8 @@ the current index and animates to the updated detent height when needed.
 
 If you want a detent to be reachable only via code (not by dragging), use the
 object form or the `programmatic` helper. Programmatic detents are excluded from
-drag snapping but can still be targeted via `index`&nbsp;updates.
+drag snapping but can still be targeted via `index`&nbsp;updates. When the
+closed detent is programmatic-only, scrim press will not dismiss the sheet.
 
 ```tsx
 <BottomSheet

--- a/README.md
+++ b/README.md
@@ -136,9 +136,8 @@ const insets = useSafeAreaInsets();
 
 #### Scrim
 
-Tapping the scrim collapses the sheet when the closed detent is user-reachable.
-If the closed detent is `programmatic(0)`, scrim press stays disabled. Use
-`scrimColor` to customize its&nbsp;color:
+Tapping the scrim collapses the sheet to the closed detent. Use `scrimColor` to
+customize the scrim&nbsp;color:
 
 ```tsx
 <ModalBottomSheet
@@ -354,8 +353,8 @@ the current index and animates to the updated detent height when needed.
 
 If you want a detent to be reachable only via code (not by dragging), use the
 object form or the `programmatic` helper. Programmatic detents are excluded from
-drag snapping but can still be targeted via `index`&nbsp;updates. When the
-closed detent is programmatic-only, scrim press will not dismiss the sheet.
+drag snapping but can still be targeted via `index` updates. If the closed
+detent is programmatic-only, tapping the scrim does not dismiss the&nbsp;sheet.
 
 ```tsx
 <BottomSheet

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -101,9 +101,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private var surfaceView: View? = null
 
   private val contentHeightMarkerLayoutListener =
-    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-      refreshDetentsFromLayout()
-    }
+    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
 
   init {
     clipChildren = false
@@ -235,16 +233,17 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   // MARK: - Prop setters
 
   fun setDetents(raw: List<Map<String, Any>>) {
-    rawDetentSpecs = raw.mapNotNull { dict ->
-      val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
-      val kind =
-        when ((dict["kind"] as? String)?.lowercase()) {
-          "content" -> DetentKind.CONTENT
-          else -> DetentKind.POINTS
-        }
-      val programmatic = dict["programmatic"] as? Boolean ?: false
-      RawDetentSpec(value = (value * density).toFloat(), kind = kind, programmatic = programmatic)
-    }
+    rawDetentSpecs =
+      raw.mapNotNull { dict ->
+        val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
+        val kind =
+          when ((dict["kind"] as? String)?.lowercase()) {
+            "content" -> DetentKind.CONTENT
+            else -> DetentKind.POINTS
+          }
+        val programmatic = dict["programmatic"] as? Boolean ?: false
+        RawDetentSpec(value = (value * density).toFloat(), kind = kind, programmatic = programmatic)
+      }
     refreshDetentsFromLayout()
   }
 

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -101,7 +101,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private var surfaceView: View? = null
 
   private val contentHeightMarkerLayoutListener =
-    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
+    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+      refreshDetentsFromLayout()
+    }
 
   init {
     clipChildren = false
@@ -233,17 +235,16 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   // MARK: - Prop setters
 
   fun setDetents(raw: List<Map<String, Any>>) {
-    rawDetentSpecs =
-      raw.mapNotNull { dict ->
-        val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
-        val kind =
-          when ((dict["kind"] as? String)?.lowercase()) {
-            "content" -> DetentKind.CONTENT
-            else -> DetentKind.POINTS
-          }
-        val programmatic = dict["programmatic"] as? Boolean ?: false
-        RawDetentSpec(value = (value * density).toFloat(), kind = kind, programmatic = programmatic)
-      }
+    rawDetentSpecs = raw.mapNotNull { dict ->
+      val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
+      val kind =
+        when ((dict["kind"] as? String)?.lowercase()) {
+          "content" -> DetentKind.CONTENT
+          else -> DetentKind.POINTS
+        }
+      val programmatic = dict["programmatic"] as? Boolean ?: false
+      RawDetentSpec(value = (value * density).toFloat(), kind = kind, programmatic = programmatic)
+    }
     refreshDetentsFromLayout()
   }
 
@@ -467,6 +468,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
 
   private val closedIndex: Int?
     get() = detentSpecs.indexOfFirst { it.height == 0f }.takeIf { it >= 0 }
+
+  private val scrimDismissIndex: Int?
+    get() = closedIndex?.takeIf { !detentSpecs[it].programmatic }
 
   private val firstNonZeroDetentHeight: Float
     get() = detentSpecs.firstOrNull { it.height > 0f }?.height ?: 0f
@@ -708,7 +712,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
           return true
         }
         MotionEvent.ACTION_UP -> {
-          val closeIndex = closedIndex
+          val closeIndex = scrimDismissIndex
           val shouldDismiss = scrimPressed && isScrimVisible()
           scrimPressed = false
           scrimTouchActive = false

--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -4,7 +4,8 @@ import UIKit
   func bottomSheetHostingView(_ view: BottomSheetHostingView, didChangeIndex index: Int)
   func bottomSheetHostingView(_ view: BottomSheetHostingView, didSettle index: Int)
   func bottomSheetHostingView(
-    _ view: BottomSheetHostingView, didChangePosition position: CGFloat, index: CGFloat)
+    _ view: BottomSheetHostingView, didChangePosition position: CGFloat, index: CGFloat
+  )
   func bottomSheetHostingView(_ view: BottomSheetHostingView, didReportError message: String)
 }
 
@@ -396,7 +397,8 @@ public final class BottomSheetHostingView: UIView {
     updateSheetVisibility(forPosition: position)
     updateInteractionState()
     eventDelegate?.bottomSheetHostingView(
-      self, didChangePosition: position, index: detentIndex(forPosition: position))
+      self, didChangePosition: position, index: detentIndex(forPosition: position)
+    )
   }
 
   private func startDisplayLink() {
@@ -507,7 +509,7 @@ public final class BottomSheetHostingView: UIView {
     let animation = CAKeyframeAnimation(keyPath: "transform.translation.y")
     let sampleCount = max(Int((duration * 120).rounded()), 1)
     animation.values = spring.keyframeValues(count: sampleCount)
-    animation.keyTimes = (0...sampleCount).map {
+    animation.keyTimes = (0 ... sampleCount).map {
       NSNumber(value: Double($0) / Double(sampleCount))
     }
     animation.duration = duration
@@ -1070,19 +1072,20 @@ private extension BottomSheetHostingView {
       forPosition: position,
       values: detentSpecs.indices.map {
         clampOpacity(scrimOpacities[min($0, scrimOpacities.count - 1)])
-      })
+      }
+    )
   }
 
-  // Fractional detent index in 0...(detentSpecs.count - 1): 0 at the shortest
-  // detent, 1 at the next, and so on, interpolated by position in between. The
-  // continuous counterpart of `onIndexChange`, so consumers can drive a backdrop
-  // or animate per detent without knowing the sheet's height.
+  /// Fractional detent index in 0...(detentSpecs.count - 1): 0 at the shortest
+  /// detent, 1 at the next, and so on, interpolated by position in between. The
+  /// continuous counterpart of `onIndexChange`, so consumers can drive a backdrop
+  /// or animate per detent without knowing the sheet's height.
   private func detentIndex(forPosition position: CGFloat) -> CGFloat {
     interpolate(forPosition: position, values: detentSpecs.indices.map { CGFloat($0) })
   }
 
-  // Interpolates a per-detent value (one per detent, by index) by the sheet
-  // position, using each detent's resolved height as the breakpoint.
+  /// Interpolates a per-detent value (one per detent, by index) by the sheet
+  /// position, using each detent's resolved height as the breakpoint.
   private func interpolate(forPosition position: CGFloat, values: [CGFloat]) -> CGFloat {
     let pairs = zip(detentSpecs.map(\.height), values)
       .map { (height: $0, value: $1) }

--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -354,6 +354,13 @@ public final class BottomSheetHostingView: UIView {
     detentSpecs.firstIndex(where: { $0.height == 0 })
   }
 
+  private var scrimDismissIndex: Int? {
+    guard let closedIndex, !detentSpecs[closedIndex].programmatic else {
+      return nil
+    }
+    return closedIndex
+  }
+
   private var firstNonZeroDetentHeight: CGFloat {
     detentSpecs.first(where: { $0.height > 0 })?.height ?? 0
   }
@@ -427,7 +434,7 @@ public final class BottomSheetHostingView: UIView {
   @objc private func handleScrimPress() {
     guard
       modal,
-      let closedIndex,
+      let closedIndex = scrimDismissIndex,
       targetIndex != closedIndex,
       activeSpring == nil || currentSheetHeight > 0.5
     else {

--- a/ios/CriticalSpring.swift
+++ b/ios/CriticalSpring.swift
@@ -36,7 +36,7 @@ struct CriticalSpring {
   /// spring on the app thread.
   func keyframeValues(count: Int) -> [CGFloat] {
     let n = max(count, 1)
-    return (0...n).map { i in
+    return (0 ... n).map { i in
       let t = duration * CFTimeInterval(i) / CFTimeInterval(n)
       return value(at: startTime + t)
     }


### PR DESCRIPTION
# Summary
Disable scrim dismissal when the closed detent is programmatic-only

## Motivation
Sometimes we need the modal to be dissmissed only by an internal action like a confirm/next button, this pr fixes the dismissal by scrim tap when detent is progammatic-only