### PR TITLE
Fix Android initial open for content detents

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -101,6 +101,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private var maxDetentHeight = Float.NaN
   private var contentHeightMarker: View? = null
   private var surfaceView: View? = null
+  private var contentDetentRefreshPosted = false
+  private var contentDetentRefreshAttempts = 0
+  private var pendingInitialContentDetentSnap = false
 
   private val contentHeightMarkerLayoutListener =
     View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
@@ -177,17 +180,21 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
       val clampedIndex = indexToApply.coerceIn(0, detentSpecs.size - 1)
 
       if (animateIn && isInvalidContentDetentTarget(clampedIndex)) {
+        hasLaidOut = true
+        pendingIndex = null
         targetIndex = clampedIndex
-        pendingIndex = clampedIndex
-        val closedTy = resolvedMaxDetentHeight(h)
-        sheetContainer.translationY = closedTy
+        pendingInitialContentDetentSnap = true
+        sheetContainer.translationY = resolvedMaxDetentHeight(h)
         emitPosition()
+        scheduleContentDetentRefresh()
         return
       }
 
       hasLaidOut = true
       pendingIndex = null
       targetIndex = clampedIndex
+      contentDetentRefreshAttempts = 0
+      pendingInitialContentDetentSnap = false
 
       if (animateIn) {
         val closedTy = resolvedMaxDetentHeight(h)
@@ -333,6 +340,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
 
     val resolvedDetents = resolveDetentSpecs()
     if (resolvedDetents == detentSpecs) {
+      if (trySnapPendingInitialContentDetent()) {
+        return
+      }
       updateScrim()
       return
     }
@@ -353,6 +363,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
         targetIndex = targetIndex.coerceIn(0, detentSpecs.size - 1)
         val newMaxHeight = resolvedMaxDetentHeight()
         val targetTy = translationY(targetIndex)
+        if (trySnapPendingInitialContentDetent()) {
+          return
+        }
         if (activeAnimation != null && isTargetingClosedDetent) {
           suppressScrimForClosingTarget = true
           hideScrim()
@@ -427,6 +440,37 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private fun isInvalidContentDetentTarget(index: Int): Boolean {
     return rawDetentSpecs.getOrNull(index)?.kind == DetentKind.CONTENT &&
       !validContentHeight().isFinite()
+  }
+
+  private fun trySnapPendingInitialContentDetent(): Boolean {
+    if (!pendingInitialContentDetentSnap || isInvalidContentDetentTarget(targetIndex)) {
+      return false
+    }
+
+    pendingInitialContentDetentSnap = false
+    contentDetentRefreshAttempts = 0
+    snapToIndex(targetIndex, 0f, emitIndexChange = false, emitSettle = true)
+    return true
+  }
+
+  private fun scheduleContentDetentRefresh() {
+    if (contentDetentRefreshPosted) return
+    contentDetentRefreshPosted = true
+    postOnAnimation {
+      contentDetentRefreshPosted = false
+      refreshContentHeightMarker()
+      refreshDetentsFromLayout()
+
+      if (isInvalidContentDetentTarget(targetIndex)) {
+        if (contentDetentRefreshAttempts < 10) {
+          contentDetentRefreshAttempts += 1
+          requestLayout()
+          scheduleContentDetentRefresh()
+        }
+      } else {
+        contentDetentRefreshAttempts = 0
+      }
+    }
   }
 
   private fun refreshContentHeightMarker() {


### PR DESCRIPTION
## Summary

Fixes an Android initial-open race when a bottom sheet targets a `content` detent before the content height marker has a valid layout position.

When the first layout sees an invalid content detent, the sheet is currently parked at the closed translation and `onLayout` returns while `hasLaidOut` is still `false`. On Android, the content height marker can become valid without the host view reliably re-entering that initial-open branch, so the sheet remains rendered offscreen even though React and the native tree both contain the sheet content.

This change keeps the sheet closed while the content detent is unresolved, marks the host as laid out, and schedules content-detent refreshes. Once the content marker is valid, it performs the pending initial `snapToIndex` with `emitSettle = true`, preserving the normal initial open semantics while avoiding a full-height intermediate sheet.

## Validation

Tested downstream in a React Native 0.83 / Expo Android app that reproduced the issue with `index={1}` and a `content` detent:

- Confirmed the original bug: sheet content was mounted but positioned offscreen on Android.
- Verified this patch makes the sheet visible at the measured content height.
- Captured a rapid screenshot burst through Metro reload; no full-height white panel or resize blink appeared.
- Rebuilt and installed Android successfully with the patched library via Yarn patch.
- Ran the app package TypeScript lint successfully.

I could not run this repository's JS lint/typecheck in a fresh clone because dependencies were not installed (`eslint` / `tsc` missing). The changed file is Kotlin-only, and the native Kotlin module was compiled successfully in the downstream Android app.
