### PR TITLE
Fix Android initial content detent open via pre-draw observer

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -105,6 +105,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private var pendingInitialContentDetentSnap = false
   private var pendingInitialContentDetentObserver: ViewTreeObserver? = null
   private var pendingInitialContentDetentPreDrawListener: ViewTreeObserver.OnPreDrawListener? = null
+  private var pendingInitialContentDetentFrames = 0
 
   private val contentHeightMarkerLayoutListener =
     View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
@@ -165,6 +166,22 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   }
 
   // MARK: - Layout
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    // A re-attach gives us a fresh, live ViewTreeObserver; the previous one was
+    // dropped on detach. Resume observing if the initial snap is still pending.
+    if (pendingInitialContentDetentSnap) {
+      observePendingInitialContentDetent()
+    }
+  }
+
+  override fun onDetachedFromWindow() {
+    // Release the listener from the soon-to-be-replaced observer and clear our
+    // references so a later re-attach registers on the new live observer.
+    removePendingInitialContentDetentObserver()
+    super.onDetachedFromWindow()
+  }
 
   override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
     super.onLayout(changed, left, top, right, bottom)
@@ -262,6 +279,18 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
     if (!hasLaidOut) {
       pendingIndex = newIndex
       targetIndex = newIndex
+      return
+    }
+
+    if (pendingInitialContentDetentSnap) {
+      // The initial open is still deferred because the target content detent is
+      // not measurable yet. Retarget the deferred snap so the requested index is
+      // reflected, then either complete it now (e.g. a points detent that is
+      // already resolvable) or keep waiting for the content to measure.
+      targetIndex = newIndex.coerceIn(0, detentSpecs.size - 1)
+      if (!trySnapPendingInitialContentDetent()) {
+        observePendingInitialContentDetent()
+      }
       return
     }
 
@@ -464,10 +493,22 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
     val observer = viewTreeObserver
     if (!observer.isAlive) return
 
+    pendingInitialContentDetentFrames = 0
     val listener =
       ViewTreeObserver.OnPreDrawListener {
         refreshContentHeightMarker()
         refreshDetentsFromLayout()
+        // refreshDetentsFromLayout() completes and stops observing via
+        // trySnapPendingInitialContentDetent() once the target is measurable.
+        // If it is still pending, this frame was unproductive: bound how many
+        // such frames we spend so a content detent that never becomes
+        // measurable cannot keep us redrawing forever.
+        if (
+          pendingInitialContentDetentSnap &&
+            ++pendingInitialContentDetentFrames >= MAX_PENDING_INITIAL_CONTENT_DETENT_FRAMES
+        ) {
+          removePendingInitialContentDetentObserver()
+        }
         true
       }
 
@@ -1169,5 +1210,19 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
     scrimPaint.color =
       Color.argb(alpha, Color.red(scrimColor), Color.green(scrimColor), Color.blue(scrimColor))
     canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), scrimPaint)
+  }
+
+  companion object {
+    // Upper bound on pre-draw passes spent waiting for the initial content
+    // detent to become measurable. This is a safety valve, not the completion
+    // mechanism: the snap is driven by the marker layout listener and the
+    // pre-draw observer, which normally resolve within a few frames. Because a
+    // pending-but-unmeasurable content detent keeps re-invalidating via
+    // updateScrim(), an unbounded observer would redraw every frame forever if
+    // the content never produces a measurable height. The budget is generous
+    // (covers pathologically slow content) but finite; once exhausted we stop
+    // observing to end the redraw loop, while the marker layout listener can
+    // still complete the snap if the content becomes measurable later.
+    private const val MAX_PENDING_INITIAL_CONTENT_DETENT_FRAMES = 240
   }
 }

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -9,6 +9,7 @@ import android.view.VelocityTracker
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import androidx.dynamicanimation.animation.DynamicAnimation
 import androidx.dynamicanimation.animation.SpringAnimation
@@ -101,6 +102,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private var maxDetentHeight = Float.NaN
   private var contentHeightMarker: View? = null
   private var surfaceView: View? = null
+  private var pendingInitialContentDetentSnap = false
+  private var pendingInitialContentDetentObserver: ViewTreeObserver? = null
+  private var pendingInitialContentDetentPreDrawListener: ViewTreeObserver.OnPreDrawListener? = null
 
   private val contentHeightMarkerLayoutListener =
     View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
@@ -177,17 +181,20 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
       val clampedIndex = indexToApply.coerceIn(0, detentSpecs.size - 1)
 
       if (animateIn && isInvalidContentDetentTarget(clampedIndex)) {
+        hasLaidOut = true
+        pendingIndex = null
         targetIndex = clampedIndex
-        pendingIndex = clampedIndex
-        val closedTy = resolvedMaxDetentHeight(h)
-        sheetContainer.translationY = closedTy
+        pendingInitialContentDetentSnap = true
+        sheetContainer.translationY = resolvedMaxDetentHeight(h)
         emitPosition()
+        observePendingInitialContentDetent()
         return
       }
 
       hasLaidOut = true
       pendingIndex = null
       targetIndex = clampedIndex
+      clearPendingInitialContentDetentSnap()
 
       if (animateIn) {
         val closedTy = resolvedMaxDetentHeight(h)
@@ -333,6 +340,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
 
     val resolvedDetents = resolveDetentSpecs()
     if (resolvedDetents == detentSpecs) {
+      if (trySnapPendingInitialContentDetent()) {
+        return
+      }
       updateScrim()
       return
     }
@@ -353,6 +363,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
         targetIndex = targetIndex.coerceIn(0, detentSpecs.size - 1)
         val newMaxHeight = resolvedMaxDetentHeight()
         val targetTy = translationY(targetIndex)
+        if (trySnapPendingInitialContentDetent()) {
+          return
+        }
         if (activeAnimation != null && isTargetingClosedDetent) {
           suppressScrimForClosingTarget = true
           hideScrim()
@@ -427,6 +440,55 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private fun isInvalidContentDetentTarget(index: Int): Boolean {
     return rawDetentSpecs.getOrNull(index)?.kind == DetentKind.CONTENT &&
       !validContentHeight().isFinite()
+  }
+
+  private fun trySnapPendingInitialContentDetent(): Boolean {
+    if (!pendingInitialContentDetentSnap || isInvalidContentDetentTarget(targetIndex)) {
+      return false
+    }
+
+    pendingInitialContentDetentSnap = false
+    removePendingInitialContentDetentObserver()
+    snapToIndex(targetIndex, 0f, emitIndexChange = false, emitSettle = true)
+    return true
+  }
+
+  private fun clearPendingInitialContentDetentSnap() {
+    pendingInitialContentDetentSnap = false
+    removePendingInitialContentDetentObserver()
+  }
+
+  private fun observePendingInitialContentDetent() {
+    if (pendingInitialContentDetentPreDrawListener != null) return
+
+    val observer = viewTreeObserver
+    if (!observer.isAlive) return
+
+    val listener =
+      ViewTreeObserver.OnPreDrawListener {
+        refreshContentHeightMarker()
+        refreshDetentsFromLayout()
+        true
+      }
+
+    // Keep the exact observer instance used for registration. Android can
+    // replace a ViewTreeObserver across attach/detach boundaries, and listeners
+    // must be removed from the same live observer that received them.
+    pendingInitialContentDetentObserver = observer
+    pendingInitialContentDetentPreDrawListener = listener
+    observer.addOnPreDrawListener(listener)
+  }
+
+  private fun removePendingInitialContentDetentObserver() {
+    val observer = pendingInitialContentDetentObserver
+    val listener = pendingInitialContentDetentPreDrawListener
+
+    if (observer?.isAlive == true && listener != null) {
+      observer.removeOnPreDrawListener(listener)
+    }
+
+    pendingInitialContentDetentObserver = null
+    pendingInitialContentDetentPreDrawListener = null
   }
 
   private fun refreshContentHeightMarker() {
@@ -980,6 +1042,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
     activeAnimation = null
     velocityTracker?.recycle()
     velocityTracker = null
+    clearPendingInitialContentDetentSnap()
     contentHeightMarker?.removeOnLayoutChangeListener(contentHeightMarkerLayoutListener)
     contentHeightMarker = null
     surfaceView = null


### PR DESCRIPTION
## Summary

Alternative to #31. This version fixes the Android initial-open timing issue for content detents without a retry budget.

When `animateIn` is enabled and the initial target depends on a content-height marker, Android can run the host `onLayout` before that marker has a valid measured height. The previous path moved the sheet to the closed translation and returned while keeping the view in the initial layout branch, so later marker/layout updates could leave the sheet mounted but visually off-screen until a remount.

This change makes that state explicit:

- `pendingInitialContentDetentSnap` records that the first open was deferred because the target content detent was not measurable yet.
- The invalid initial path marks the host as laid out, keeps the sheet closed, emits the closed position, and starts observing pre-draws so the content marker can be refreshed as soon as Android is about to draw the next frame.
- `refreshDetentsFromLayout()` performs the deferred snap once the target detent becomes valid, preserving the normal initial-open animation behavior and avoiding index-change emission for the deferred first snap.
- The observer is removed on success, normal initial layout, or destroy. The exact `ViewTreeObserver` instance is stored intentionally because Android can replace it across attach/detach boundaries, and listeners must be removed from the same live observer that received them.

## Validation

- `git diff --check`
- Applied the same observer fix to the Rosk app dependency and rebuilt `@rosk/pro-native-app` on Android. The build compiled `:swmansion_react-native-bottom-sheet:compileDebugKotlin` successfully.
- Verified on a physical Pixel 7 running Android API 37 that `MissionFeedbackBottomSheet` opens visibly in front of the app.
- Verified the React Native component tree after reload shows the mission feedback title, form rows, textarea, and submit button on-screen.
- Captured a 45-frame Metro reload sequence on the Pixel 7; after the normal Metro loading frames, the app returned with the sheet visible, with no settled frame where the opened sheet was hidden behind or below the app.

## Notes

This intentionally avoids app-level workarounds, changing `nativeOverlay`, changing detent semantics, or adding arbitrary frame retry counts.