### PR TITLE
fix: android  bottom sheet position reset on unmount

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -998,7 +998,6 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
     activePointerId = MotionEvent.INVALID_POINTER_ID
     scrimPressed = false
     scrimTouchActive = false
-    sheetContainer.translationY = 0f
     scrimProgress = 0f
     suppressScrimForClosingTarget = false
     sheetContainer.removeAllViews()


### PR DESCRIPTION
# Summary
Bottom sheet resets the postion on umount

# Bug 🐞

https://github.com/user-attachments/assets/359cad6c-a09d-4d04-a851-16fad082d34e


# Fixed ✅

https://github.com/user-attachments/assets/ee509bc0-8f1e-4b31-91d0-d503766f0e6c

