### PR TITLE
fix(android): restore React Native <0.82 Android build (2-arg JSTouchDispatcher overloads)

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
@@ -19,7 +19,6 @@ import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.WindowCompat
 import com.facebook.react.bridge.LifecycleEventListener
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.JSTouchDispatcher
@@ -407,7 +406,8 @@ private class BottomSheetDialogRootView(context: ThemedReactContext) :
 
   override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let { dispatcher ->
-      jSTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      // 2-arg JSTouchDispatcher overloads throughout — see onChildStartedNativeGesture below.
+      jSTouchDispatcher.handleTouchEvent(event, dispatcher)
       jSPointerDispatcher?.handleMotionEvent(event, dispatcher, true)
     }
     return super.onInterceptTouchEvent(event)
@@ -416,7 +416,7 @@ private class BottomSheetDialogRootView(context: ThemedReactContext) :
   @SuppressLint("ClickableViewAccessibility")
   override fun onTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let { dispatcher ->
-      jSTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      jSTouchDispatcher.handleTouchEvent(event, dispatcher)
       jSPointerDispatcher?.handleMotionEvent(event, dispatcher, false)
     }
     super.onTouchEvent(event)
@@ -437,10 +437,16 @@ private class BottomSheetDialogRootView(context: ThemedReactContext) :
     return super.onHoverEvent(event)
   }
 
-  @OptIn(UnstableReactNativeAPI::class)
   override fun onChildStartedNativeGesture(childView: View?, ev: MotionEvent) {
     eventDispatcher?.let { dispatcher ->
-      jSTouchDispatcher.onChildStartedNativeGesture(ev, dispatcher, reactContext)
+      // Use the 2-arg JSTouchDispatcher overloads here and in handleTouchEvent. The 3-arg forms
+      // opt into Fabric's active-touch tracking: handleTouchEvent marks the touch and this method
+      // sweeps it when a native child (e.g. a nested scrollable) takes over. The 3-arg
+      // onChildStartedNativeGesture that performs that sweep only exists on RN 0.82+ (issue #35),
+      // so to keep mark/sweep consistent and compile across the >=0.76 peer range we opt out of
+      // tracking entirely. Once support for RN 0.81 and below is dropped, this call and the
+      // handleTouchEvent calls can move back to the 3-arg overloads.
+      jSTouchDispatcher.onChildStartedNativeGesture(ev, dispatcher)
       jSPointerDispatcher?.onChildStartedNativeGesture(childView, ev, dispatcher)
     }
   }


### PR DESCRIPTION
Fixes #35.

> One of **two alternative proposals** for #35. The companion PR (#37) keeps the active-touch sweep intact on RN 0.82+ via a small reflection shim; **this** PR is the simpler option and opts out of that tracking entirely. Pick whichever matches the project's preference.

## Problem
`BottomSheetView`'s native-overlay dialog `BottomSheetDialogRootView` (added in `2487ece`, "feat: add native overlay modal sheets") forwards touches to JS through `JSTouchDispatcher`, mirroring RN's own `ReactModalHostView.DialogRootViewGroup`. It calls the **3-arg** `onChildStartedNativeGesture(ev, dispatcher, reactContext)`.

That 3-arg overload was added in **React Native 0.82.0** (verified by diffing `JSTouchDispatcher.kt` at tags `v0.81.0` vs `v0.82.0`). The package's `react-native` peer dependency is `>=0.76.0`, but on **0.76–0.81 only the 2-arg overload exists**, so Android fails to compile:

```
BottomSheetView.kt: Too many arguments for 'fun onChildStartedNativeGesture(MotionEvent, EventDispatcher)'
```

(Same class of breakage as the already-fixed #25, from the same `2487ece` commit.)

## Background — what the 3-arg overloads do
RN's `JSTouchDispatcher` 3-arg overloads opt into **Fabric active-touch tracking**:
- 3-arg `handleTouchEvent` → `markActiveTouchForTag` on touch-down (and sweeps on UP/CANCEL)
- 3-arg `onChildStartedNativeGesture` → `sweepActiveTouchForTag` when a native child *steals* the gesture mid-touch (the path where a normal UP/CANCEL never returns through `JSTouchDispatcher`)

The 2-arg overloads pass `reactContext = null`, making mark/sweep no-ops — i.e. they opt out of tracking. (Mechanism appears in RN's own code, e.g. facebook/react-native#48007; the "clear state when a native gesture starts or events don't re-fire" rationale is in facebook/react-native#37638; symptom class in facebook/react-native#36710.)

## Fix
Use the **2-arg** overloads for **both** `handleTouchEvent` and `onChildStartedNativeGesture`. Compiles across the whole `>=0.76.0` range and stays internally consistent: we never mark, so there's nothing to sweep.

Downgrading *only* `onChildStartedNativeGesture` would be subtly wrong — `handleTouchEvent` would still mark, but the takeover sweep would be gone, stranding active-touch state. So both drop to 2-arg together.

## Trade-off
On RN 0.82+ this opts out of the active-touch sweep the dialog previously performed. This matches how other libraries' dialog/overlay root views do it — **react-native-screens** (`BottomSheetDialogRootView`), **wix/react-native-navigation** (`ModalContentLayout`), and **bluesky's bottom-sheet** (`DialogRootViewGroup`) all use the 2-arg `JSTouchDispatcher` form. To instead preserve the sweep on 0.82+, see the companion reflection PR. Once the minimum supported RN is `>=0.82`, both calls can return to the 3-arg overloads.

## Verification
- Fresh **RN 0.81.5** app (New Architecture — the exact config from #35) built against this change: `BUILD SUCCESSFUL`; the `compileDebugKotlin` task that previously failed now passes.
- Ran on an emulator: opened the `nativeOverlay` `ModalBottomSheet`, scrolled a nested list inside it (the native-gesture-takeover path) — works, no crashes/JS errors.
- Also compiles on RN 0.85 (repo dev version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
