### PR TITLE
fix(android): restore React Native <0.82 Android build (reflective onChildStartedNativeGesture)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,9 @@ android {
   defaultConfig {
     minSdkVersion getExtOrDefault("minSdkVersion")
     targetSdkVersion getExtOrDefault("targetSdkVersion")
+    // Ships the keep rule for the reflectively-resolved JSTouchDispatcher overload (see
+    // JSTouchDispatcherCompat.kt) to consuming apps' R8/ProGuard.
+    consumerProguardFiles "proguard-rules.pro"
   }
 
   buildFeatures {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,8 @@
+# JSTouchDispatcherCompat resolves this 3-arg overload reflectively by name on RN >= 0.82
+# (see JSTouchDispatcherCompat.kt). Keep it so R8/ProGuard in release builds never renames it
+# away, which would make the reflective lookup fall back to the 2-arg overload and silently drop
+# the active-touch sweep. Remove this rule together with the shim once the minimum supported
+# React Native is >= 0.82.
+-keep class com.facebook.react.uimanager.JSTouchDispatcher {
+    public void onChildStartedNativeGesture(android.view.MotionEvent, com.facebook.react.uimanager.events.EventDispatcher, com.facebook.react.bridge.ReactContext);
+}

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
@@ -19,7 +19,6 @@ import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.WindowCompat
 import com.facebook.react.bridge.LifecycleEventListener
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.JSTouchDispatcher
@@ -437,10 +436,13 @@ private class BottomSheetDialogRootView(context: ThemedReactContext) :
     return super.onHoverEvent(event)
   }
 
-  @OptIn(UnstableReactNativeAPI::class)
   override fun onChildStartedNativeGesture(childView: View?, ev: MotionEvent) {
     eventDispatcher?.let { dispatcher ->
-      jSTouchDispatcher.onChildStartedNativeGesture(ev, dispatcher, reactContext)
+      // Sweeps the active touch marked by handleTouchEvent when a native child takes over the
+      // gesture. The 3-arg overload that performs the sweep only exists on RN 0.82+, so it is
+      // resolved through a compat shim (see JSTouchDispatcherCompat) that uses it when present
+      // and falls back to the 2-arg overload on RN 0.76-0.81 (issue #35).
+      jSTouchDispatcher.onChildStartedNativeGestureCompat(ev, dispatcher, reactContext)
       jSPointerDispatcher?.onChildStartedNativeGesture(childView, ev, dispatcher)
     }
   }

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/JSTouchDispatcherCompat.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/JSTouchDispatcherCompat.kt
@@ -1,0 +1,57 @@
+package com.swmansion.reactnativebottomsheet
+
+import android.view.MotionEvent
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.JSTouchDispatcher
+import com.facebook.react.uimanager.events.EventDispatcher
+import java.lang.reflect.Method
+
+/*
+ * Compatibility shim for JSTouchDispatcher.onChildStartedNativeGesture across React Native
+ * versions. Self-contained so it can be deleted in one step (see "WHEN TO REMOVE").
+ *
+ * WHY THIS EXISTS
+ * React Native 0.82 added a 3-arg overload
+ * `onChildStartedNativeGesture(MotionEvent, EventDispatcher, ReactContext)` that sweeps the active
+ * touch for the gesture's target tag (the counterpart to the mark performed by the 3-arg
+ * `handleTouchEvent`, which BottomSheetView keeps using). That overload does not exist on the
+ * 0.76-0.81 React Natives still allowed by the `react-native` peer dependency, so referencing it
+ * directly fails to compile there (issue #35).
+ *
+ * WHAT IT DOES
+ * Resolves the 3-arg overload reflectively once and uses it when present (RN >= 0.82), preserving
+ * the active-touch sweep so it stays paired with the mark from `handleTouchEvent`. Falls back to
+ * the always-available 2-arg overload on RN 0.76-0.81 (where no sweep-on-takeover exists anyway,
+ * matching React Native's own behavior on those versions). A `-keep` rule in proguard-rules.pro
+ * guarantees the reflected method survives R8 so release builds never silently lose the sweep.
+ *
+ * WHEN TO REMOVE
+ * Once the minimum supported React Native is >= 0.82: delete this file and the matching rule in
+ * proguard-rules.pro, then call the 3-arg overload directly at the BottomSheetView call site,
+ *   jSTouchDispatcher.onChildStartedNativeGesture(ev, dispatcher, reactContext)
+ * (annotated with `@OptIn(UnstableReactNativeAPI::class)`).
+ */
+private val onChildStartedNativeGestureWithContext: Method? =
+  try {
+    JSTouchDispatcher::class.java.getMethod(
+      "onChildStartedNativeGesture",
+      MotionEvent::class.java,
+      EventDispatcher::class.java,
+      ReactContext::class.java,
+    )
+  } catch (e: NoSuchMethodException) {
+    null
+  }
+
+internal fun JSTouchDispatcher.onChildStartedNativeGestureCompat(
+  event: MotionEvent,
+  eventDispatcher: EventDispatcher,
+  reactContext: ReactContext,
+) {
+  val withContext = onChildStartedNativeGestureWithContext
+  if (withContext != null) {
+    withContext.invoke(this, event, eventDispatcher, reactContext)
+  } else {
+    onChildStartedNativeGesture(event, eventDispatcher)
+  }
+}


### PR DESCRIPTION
Refs #35. Alternative to #36 (the minimal 2-arg approach) — these are two proposals for the same issue; pick one.

> **#36** opts out of Fabric active-touch tracking entirely (simplest; matches react-native-screens). **This** PR keeps RN 0.82+ behavior byte-for-byte by resolving the version-specific overload reflectively.

## Problem
`BottomSheetView`'s native-overlay dialog `BottomSheetDialogRootView` (added in `2487ece`) mirrors RN's own `ReactModalHostView.DialogRootViewGroup` and calls the **3-arg** `onChildStartedNativeGesture(ev, dispatcher, reactContext)`.

That overload was added in **React Native 0.82.0** (verified by diffing `JSTouchDispatcher.kt` at `v0.81.0` vs `v0.82.0`). The `react-native` peer dependency is `>=0.76.0`, but on **0.76–0.81 only the 2-arg overload exists**, so Android fails to compile (same class as the already-fixed #25, from the same `2487ece` commit):

```
BottomSheetView.kt: Too many arguments for 'fun onChildStartedNativeGesture(MotionEvent, EventDispatcher)'
```

## Why only this one call needs special handling
The dialog also calls the 3-arg `handleTouchEvent` (in `onInterceptTouchEvent`/`onTouchEvent`). The two 3-arg overloads are a matched pair for Fabric active-touch tracking:
- 3-arg `handleTouchEvent` → `markActiveTouchForTag` on touch-down
- 3-arg `onChildStartedNativeGesture` → `sweepActiveTouchForTag` when a native child takes over the gesture

But their availability differs:

| call | 3-arg overload available since |
|---|---|
| `handleTouchEvent` | **0.76** — whole peer range (verified in 0.76.0 source) |
| `onChildStartedNativeGesture` | **0.82** |

So `handleTouchEvent` stays a plain 3-arg call (compiles everywhere), and **only `onChildStartedNativeGesture` needs version handling** — exactly why #35 flagged only that call.

## Fix
A self-contained `JSTouchDispatcherCompat.kt` resolves the 3-arg `onChildStartedNativeGesture` **reflectively** (cached once): used when present (RN ≥ 0.82) so the active-touch sweep stays paired with the mark, with a 2-arg fallback on 0.76–0.81. `handleTouchEvent` is left at 3-arg, so tracking on 0.82+ is unchanged.

This mirrors **react-native-keyboard-controller**'s `JSPointerDispatcherCompat` (same reflective approach for the sibling `JSPointerDispatcher` overload change).

A consumer ProGuard `-keep` rule (`proguard-rules.pro`, shipped via `consumerProguardFiles`) keeps R8 from renaming the reflected method in release builds, so it can never silently fall back and drop the sweep.

Everything is isolated to one shim file + one keep rule, each with a "remove when min RN ≥ 0.82" note.

## Behavior matches RN's own modal, per version
Verified against RN source — identical to `ReactModalHostView` on every supported version:
- **0.76–0.81:** marks (3-arg `handleTouchEvent`) without a takeover-sweep — RN's inherent pre-0.82 behavior (the sweep overload didn't exist yet).
- **0.82+:** marks and sweeps.

So this introduces no behavior change relative to React Native itself on any version.

## Verification
Real apps built + run on a device, both New Architecture:
- **RN 0.81.5** (the exact config from #35): `BUILD SUCCESSFUL`; opened the `nativeOverlay` `ModalBottomSheet`, scrolled a nested list (takeover → 2-arg fallback) — works, no errors.
- **RN 0.85.3**: `BUILD SUCCESSFUL`; same flow exercises the **reflective 3-arg sweep** — works, no `InvocationTargetException`/`NoSuchMethod`/crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
