### PR TITLE
fix(ios): handle nested horizontal scroll views during scroll negotiation

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -810,8 +810,9 @@ public final class BottomSheetHostingView: UIView {
     let maxCandidateHeight = candidates.map { detentSpecs[$0].height }.max() ?? 0
     // Below max: allow drag in either direction to reach other detents.
     guard currentSheetHeight >= maxCandidateHeight - 0.5 else { return true }
-    // At max: only allow downward drag, and only when the scroll view (if any)
-    // is at its top edge — otherwise the scroll view should handle the gesture.
+    // At max: only allow downward drag, and only when every vertically scrollable
+    // view under the touch is at its relevant edge. Otherwise, a scroll view
+    // should handle the gesture.
     if velocity.y < 0 {
       return false
     }
@@ -820,12 +821,22 @@ public final class BottomSheetHostingView: UIView {
     guard let scrollView = scrollView(containing: locationInContainer, in: sheetContainer) else {
       return true
     }
-    let inverted = isViewInverted(scrollView)
-    if inverted {
-      let maxOffsetY = scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom
-      return scrollView.contentOffset.y >= maxOffsetY
+    var node: UIView? = scrollView
+    while let view = node, view !== self {
+      if let candidate = view as? UIScrollView, isVerticallyScrollable(candidate) {
+        if isViewInverted(candidate) {
+          let maxOffsetY =
+            candidate.contentSize.height - candidate.bounds.height + candidate.adjustedContentInset.bottom
+          if candidate.contentOffset.y < maxOffsetY - 0.5 {
+            return false
+          }
+        } else if candidate.contentOffset.y > 0.5 {
+          return false
+        }
+      }
+      node = view.superview
     }
-    return scrollView.contentOffset.y <= 0
+    return true
   }
 
   private var resolvedMaxDetentHeight: CGFloat {


### PR DESCRIPTION
Refs #38.

Problem
On iOS, scrollable gesture negotiation at the max detent only considered the innermost `UIScrollView` found under the touch.

This breaks when a vertical drag starts on a nested horizontal scroll view, such as a carousel inside a vertical `FlatList`. The horizontal child can still pass the library's vertical-scrollability check because of vertical bounce behavior or small `contentSize.height` / `bounds.height` differences. Since that child usually has `contentOffset.y == 0`, the sheet treats it as being at the top and takes over the downward drag.

As a result, the sheet collapses even when the enclosing vertical list is still scrolled and should handle the gesture.

Fix
When the sheet is already at its max detent and receives a downward drag, the gesture negotiation now walks from the scroll view found under the touch up through its scrollable ancestors.

The sheet only begins handling the gesture when every vertically scrollable `UIScrollView` in that chain is already at its relevant edge:
- non-inverted scroll views must be at the top
- inverted scroll views must be at the bottom

If any enclosing vertical scroll view can still consume the drag, the sheet does not begin its pan gesture, allowing the scroll view to handle the interaction instead.

This keeps the previous behavior for simple scroll views while fixing nested horizontal scroll views inside vertically scrollable content.

Verification
- `bun run typecheck`
- `bun run lint`

Note
The affected behavior is iOS-specific. I verified the code-level checks locally, but manual iOS validation should be done on macOS/Xcode.