### PR TITLE
fix(ios): negotiate scroll vs. sheet against the full scrollable ancestor chain

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -766,15 +766,6 @@ public final class BottomSheetHostingView: UIView {
     return scrollView.alwaysBounceVertical || scrollView.contentSize.height > visibleHeight
   }
 
-  private func isViewInverted(_ view: UIView) -> Bool {
-    var current: UIView? = view
-    while let v = current, v !== sheetContainer {
-      if v.transform.d < 0 { return true }
-      current = v.superview
-    }
-    return false
-  }
-
   private func scrollView(containing location: CGPoint, in view: UIView) -> UIScrollView? {
     for subview in view.subviews.reversed() {
       let locationInSubview = view.convert(location, to: subview)
@@ -810,22 +801,52 @@ public final class BottomSheetHostingView: UIView {
     let maxCandidateHeight = candidates.map { detentSpecs[$0].height }.max() ?? 0
     // Below max: allow drag in either direction to reach other detents.
     guard currentSheetHeight >= maxCandidateHeight - 0.5 else { return true }
-    // At max: only allow downward drag, and only when the scroll view (if any)
-    // is at its top edge — otherwise the scroll view should handle the gesture.
+    // At max: only allow a downward drag, and only when no scroller under the touch can
+    // still absorb it (see the ancestor walk below) — otherwise a scroller handles it.
     if velocity.y < 0 {
       return false
     }
 
     let locationInContainer = panGesture.location(in: sheetContainer)
-    guard let scrollView = scrollView(containing: locationInContainer, in: sheetContainer) else {
+    guard let touchedScrollView = scrollView(containing: locationInContainer, in: sheetContainer) else {
       return true
     }
-    let inverted = isViewInverted(scrollView)
-    if inverted {
-      let maxOffsetY = scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom
-      return scrollView.contentOffset.y >= maxOffsetY
+
+    // Collapse the sheet only when EVERY vertically-scrollable scroller under the touch is
+    // already at its relevant edge; if any of them can still scroll, the gesture belongs to
+    // that scroller. Inspecting only the innermost scroller breaks on a nested *horizontal*
+    // carousel: it can pass isVerticallyScrollable(_:) via vertical bounce or a slightly
+    // taller contentSize, yet its contentOffset.y is always 0 ("at top"), so the sheet
+    // collapsed while the enclosing vertical list was still mid-scroll.
+    //
+    // Walk the touched scroller and its ancestors up to the sheet container, resolving
+    // inversion top-down as we go: a view is inverted when it — or any ancestor up to the
+    // container — has a flipped vertical axis. edgeTolerance absorbs a sub-pixel residual so
+    // the sheet can still collapse when a list is effectively, if not exactly, at its edge.
+    let edgeTolerance: CGFloat = 0.5
+
+    var chain: [UIView] = []
+    var node: UIView? = touchedScrollView
+    while let view = node, view !== sheetContainer {
+      chain.append(view)
+      node = view.superview
     }
-    return scrollView.contentOffset.y <= 0
+
+    var inverted = false
+    for view in chain.reversed() {
+      inverted = inverted || view.transform.d < 0
+      guard let candidate = view as? UIScrollView, isVerticallyScrollable(candidate) else {
+        continue
+      }
+      if inverted {
+        let maxOffsetY =
+          candidate.contentSize.height - candidate.bounds.height + candidate.adjustedContentInset.bottom
+        if candidate.contentOffset.y < maxOffsetY - edgeTolerance { return false }
+      } else if candidate.contentOffset.y > edgeTolerance {
+        return false
+      }
+    }
+    return true
   }
 
   private var resolvedMaxDetentHeight: CGFloat {


### PR DESCRIPTION
Refs #38.

## Problem

At the max detent, scroll/sheet gesture negotiation only inspected the innermost `UIScrollView` found under the touch.

A nested *horizontal* carousel inside a vertical `FlatList` can pass `isVerticallyScrollable(_:)` — via `alwaysBounceVertical`, or a `contentSize.height` a hair taller than its bounds — yet its `contentOffset.y` is always `0` ("at top"). So a downward drag that starts on the carousel was read as "scroll view is at its top edge," and the sheet collapsed even though the enclosing vertical list was still mid-scroll and should have taken the gesture.

## Fix

When the sheet is at its max detent and receives a downward drag, walk the scroll view found under the touch *and* its scrollable ancestors. The sheet only begins its pan when **every** vertically-scrollable `UIScrollView` in that chain is already at its relevant edge (top for normal scrollers, bottom for inverted). If any enclosing vertical scroll view can still consume the drag, the sheet defers to it.

Inversion is resolved in a single top-down pass over the chain — `inverted(child) == child.transform.d < 0 || inverted(parent)` — which folds in the former `isViewInverted(_:)` helper (now removed) and avoids re-walking ancestors for every scroller. The at-edge comparison uses a named sub-pixel `edgeTolerance` so a fractional residual offset doesn't leave the sheet unable to collapse.

This keeps the existing behavior for simple/single scroll views (they're just the one-element case of the walk) while fixing nested horizontal scrollers inside vertically scrollable content.

## Validation

Run as a local patch on **React Native 0.85.3** (New Architecture / Fabric, Hermes), `@swmansion/react-native-bottom-sheet` 0.15.x, and verified on **both the iOS simulator and a physical device**:

- A downward drag on a nested horizontal carousel while the outer list is mid-scroll now scrolls the outer list.
- Collapsing the sheet from the list's top edge still works.
- Intermediate-detent drags and drags on non-scrollable areas are unchanged.
