### PR TITLE
fix(ios):  content interaction after pan ends

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -651,6 +651,7 @@ public final class BottomSheetHostingView: UIView {
 
     case .ended:
       isPanning = false
+      setContentInteractionEnabled(true)
       let velocity = gesture.velocity(in: self).y
       let currentHeight = maxHeight - sheetContainer.transform.ty
       let index =


### PR DESCRIPTION
Refs #41.

Problem
On iOS, sheet content interaction is disabled when the pan gesture begins in order to cancel in-flight presses during a sheet drag.

However, the `.ended` path did not re-enable content interaction directly. Instead, it relied on the snap animation completing and calling `finishSpring()`. If that animation was removed or interrupted before reporting `finished == true`, `finishSpring()` would not run and the sheet content could remain permanently non-interactive until a later drag completed successfully.

Fix
Re-enable content interaction directly in the `.ended` pan gesture path, immediately after marking the pan as finished.

At that point the drag gesture is over, so controls inside the sheet should be tappable again regardless of whether the following snap animation completes, is interrupted, or has zero distance.

Verification
- `bun run typecheck`
- `bun run lint`

Note
The affected behavior is iOS-specific. I verified the code-level checks locally; manual behavior validation should be done on iOS with macOS/Xcode.