### PR TITLE
feature(ios): hand off the drag to nested scrollables at the max detent (#22)

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -91,6 +91,11 @@ public final class BottomSheetHostingView: UIView {
   private var panStartingIndex: Int?
   private var activeDragRange: (minTy: CGFloat, maxTy: CGFloat)?
   private var activeDragDetentSpecs: [DetentSpec]?
+  // The scroller this drag scrolls once the sheet maxes out. Bound at gesture
+  // start so it stays valid even as the finger drifts up over the header.
+  private weak var dragScroller: UIScrollView?
+  private var dragScrollerInverted = false
+  private let edgeTolerance: CGFloat = 0.5
   private var isContentInteractionDisabled = false
   private var contentHeightMarker: UIView?
   private weak var surfaceView: UIView?
@@ -625,6 +630,8 @@ public final class BottomSheetHostingView: UIView {
     case .began:
       isPanning = true
       scrimPinnedFull = false
+      dragScroller = scrollView(containing: panGesture.location(in: sheetContainer), in: sheetContainer)
+      dragScrollerInverted = dragScroller.map { isInverted($0) } ?? false
       panStartingIndex = targetIndex
       activeDragDetentSpecs = detentSpecs
       activeDragRange = snapshotDraggableRange(including: targetIndex, in: detentSpecs)
@@ -643,18 +650,23 @@ public final class BottomSheetHostingView: UIView {
       let delta = gesture.translation(in: self).y
       gesture.setTranslation(.zero, in: self)
       let range = activeDragRange ?? draggableRange(including: panStartingIndex)
-      let minTy = range.minTy
-      let maxTy = range.maxTy
-      let newTy = max(minTy, min(maxTy, sheetContainer.transform.ty + delta))
-      sheetContainer.transform = CGAffineTransform(translationX: 0, y: newTy)
+      if delta < 0 {
+        liftSheetThenScrollContent(by: -delta, within: range)
+      } else if delta > 0 {
+        scrollContentThenCollapseSheet(by: delta, within: range)
+      }
       emitPosition()
 
     case .ended:
       isPanning = false
       let velocity = gesture.velocity(in: self).y
+      // Don't let a residual downward velocity collapse the sheet mid-scroll.
+      let stayOpen = handoffContentIsScrolled()
       let currentHeight = maxHeight - sheetContainer.transform.ty
       let index =
-        activeDragDetentSpecs.flatMap {
+        stayOpen
+        ? maxHeightSnapIndex(including: panStartingIndex)
+        : activeDragDetentSpecs.flatMap {
           $0.count == detentSpecs.count ? $0 : nil
         }.map {
           snapshotBestSnapIndex(
@@ -671,15 +683,19 @@ public final class BottomSheetHostingView: UIView {
       panStartingIndex = nil
       activeDragRange = nil
       activeDragDetentSpecs = nil
-      snapToIndex(index, velocity: velocity)
+      dragScroller = nil
+      snapToIndex(index, velocity: stayOpen ? 0 : velocity)
 
     case .cancelled:
       isPanning = false
       setContentInteractionEnabled(true)
       let cancelVelocity = gesture.velocity(in: self).y
+      let stayOpen = handoffContentIsScrolled()
       let cancelHeight = maxHeight - sheetContainer.transform.ty
       let cancelIndex =
-        activeDragDetentSpecs.flatMap {
+        stayOpen
+        ? maxHeightSnapIndex(including: panStartingIndex)
+        : activeDragDetentSpecs.flatMap {
           $0.count == detentSpecs.count ? $0 : nil
         }.map {
           snapshotBestSnapIndex(
@@ -696,17 +712,50 @@ public final class BottomSheetHostingView: UIView {
       panStartingIndex = nil
       activeDragRange = nil
       activeDragDetentSpecs = nil
-      snapToIndex(cancelIndex, velocity: cancelVelocity)
+      dragScroller = nil
+      snapToIndex(cancelIndex, velocity: stayOpen ? 0 : cancelVelocity)
 
     case .failed:
       isPanning = false
       panStartingIndex = nil
       activeDragRange = nil
       activeDragDetentSpecs = nil
+      dragScroller = nil
       setContentInteractionEnabled(true)
 
     default:
       break
+    }
+  }
+
+  // Lift the sheet to its tallest detent, then hand leftover travel to the list (#22).
+  private func liftSheetThenScrollContent(
+    by distance: CGFloat, within range: (minTy: CGFloat, maxTy: CGFloat)
+  ) {
+    let ty = sheetContainer.transform.ty
+    let lift = min(distance, max(0, ty - range.minTy))
+    if lift > 0 {
+      sheetContainer.transform = CGAffineTransform(translationX: 0, y: ty - lift)
+    }
+    let leftover = distance - lift
+    if leftover > edgeTolerance {
+      driveScroll(by: leftover, forward: true)
+    }
+  }
+
+  // Mirror: scroll the list back to its top before collapsing, so the sheet never
+  // moves under still-scrolled content.
+  private func scrollContentThenCollapseSheet(
+    by distance: CGFloat, within range: (minTy: CGFloat, maxTy: CGFloat)
+  ) {
+    let ty = sheetContainer.transform.ty
+    let sheetAtMax = ty <= range.minTy + edgeTolerance
+    var collapse = distance
+    if sheetAtMax {
+      collapse -= driveScroll(by: distance, forward: false)
+    }
+    if collapse > 0 {
+      sheetContainer.transform = CGAffineTransform(translationX: 0, y: min(range.maxTy, ty + collapse))
     }
   }
 
@@ -780,6 +829,47 @@ public final class BottomSheetHostingView: UIView {
       }
     }
     return nil
+  }
+
+  private func isInverted(_ view: UIView) -> Bool {
+    sequence(first: view, next: \.superview)
+      .prefix { $0 !== sheetContainer }
+      .contains { $0.transform.d < 0 }
+  }
+
+  private func offsetBounds(_ scrollView: UIScrollView) -> (min: CGFloat, max: CGFloat) {
+    let minY = -scrollView.adjustedContentInset.top
+    let maxY =
+      scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom
+    return (min: minY, max: max(minY, maxY))
+  }
+
+  // Remaining scroll travel for the bound list in the drag direction (forward =
+  // drag-up); an inverted list moves toward the opposite content edge.
+  private func scrollRoom(forward: Bool) -> CGFloat {
+    guard let scrollView = dragScroller else { return 0 }
+    let bounds = offsetBounds(scrollView)
+    let offset = scrollView.contentOffset.y
+    return max(0, forward != dragScrollerInverted ? bounds.max - offset : offset - bounds.min)
+  }
+
+  // Scrolls the bound list up to `distance` (clamped, no overscroll); returns the distance moved.
+  @discardableResult
+  private func driveScroll(by distance: CGFloat, forward: Bool) -> CGFloat {
+    guard let scrollView = dragScroller else { return 0 }
+    let moved = min(distance, scrollRoom(forward: forward))
+    guard moved > 0 else { return 0 }
+    scrollView.contentOffset.y += forward != dragScrollerInverted ? moved : -moved
+    return moved
+  }
+
+  private func handoffContentIsScrolled() -> Bool {
+    scrollRoom(forward: false) > edgeTolerance
+  }
+
+  private func maxHeightSnapIndex(including index: Int?) -> Int {
+    let candidates = snapCandidateIndices(including: index)
+    return candidates.max(by: { detent(at: $0).height < detent(at: $1).height }) ?? targetIndex
   }
 
   override public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {


### PR DESCRIPTION
## Summary

Implements #22.

When a `BottomSheet` contains a scrollable (`FlatList`/`ScrollView`) and you drag up from a lower detent, the sheet now expands to its tallest detent and then — **within the same continuous gesture** — hands the remaining travel to the nested scrollable so the content keeps scrolling. Previously the sheet kept consuming the upward drag after it was fully expanded (`onPositionChange` repeatedly fired the same value), so you had to lift your finger and start a second gesture to scroll the content.

This brings the drag in line with how native iOS sheets behave (and as described in #22): one pan moves the sheet to its top position *and then* starts scrolling the nested content.

## Behavior

- **Drag up:** lift the sheet to its tallest detent, then scroll the bound list with the leftover travel.
- **Drag back down (same gesture):** scroll the list back to its top first, then collapse — so the sheet never moves under still-scrolled content.
- **Release while mid-scroll:** the sheet stays at max; a residual downward velocity won't collapse it. This preserves the asymmetry agreed in the issue thread (don't accidentally close the sheet).
- Works with both normal and **inverted** (chat-style) lists.

## Implementation

All in `ios/BottomSheetHostingView.swift`, within the existing `handlePan` flow:
- `.began` binds the gesture to the scrollable under the touch (reusing the existing `scrollView(containing:in:)` helper) and records whether it's inverted.
- `.changed` splits the drag between the sheet and the bound scroller (`liftSheetThenScrollContent` / `scrollContentThenCollapseSheet`).
- `.ended` / `.cancelled` keep the sheet open when the content is still scrolled.

The scroll-vs-sheet negotiation in `gestureRecognizerShouldBegin` (the ancestor-chain logic from #40) is **untouched**.

## Scope & limitations

- **No fling momentum** after release. The handoff tracks the finger 1:1 but doesn't carry deceleration into the scroller, so the content stops where you release rather than gliding. This keeps the change minimal and fully contained in `handlePan`; adding momentum would mean driving a deceleration curve on `contentOffset` (the existing `CADisplayLink` could be reused) as a parallel animation to the sheet spring — a reasonable follow-up if the dead-stop feel matters.
- The handoff targets the innermost *vertically-scrollable* view under the initial touch and does not re-run #40's ancestor-chain resolution. A normal horizontal carousel is skipped (it isn't vertically scrollable), so the enclosing list is used. In the uncommon case where a nested horizontal scroller itself passes the vertical-scrollable check (vertical bounce, or `contentSize` slightly taller than its bounds — the #38 scenario), a drag starting on it would hand off to that scroller rather than the enclosing list.

## Alternatives considered

A more "native-feeling" approach is the scroll-view-driven model (let the inner `UIScrollView`'s own pan drive the gesture and observe `contentOffset`), which gets momentum and rubber-banding for free. It was not taken here because it would rework the library's core gesture model (which uses a single container pan) and overlaps with the negotiation in #40 — a much larger, riskier change. This PR keeps to the existing single-pan design and stays contained in `handlePan`.

## Testing

Verified on the iOS simulator (iPhone 16 Pro Max) with the "Inline with FlatList" example:
- Continuous up-drag from the middle detent expands the sheet and scrolls the list in one gesture.
- Down-drag scrolls content back, then collapses; releasing mid-scroll keeps the sheet open.
- Inverted list scrolls in the correct direction.
- Drag starting on the nested horizontal carousel ("Inline with nested FlatLists") still scrolls the outer list — no regression to #40.
