### PR TITLE
fix(android): dismiss native-overlay sheet on hardware back instead of forwarding to host activity

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -1205,6 +1205,21 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
 
   private fun isScrimVisible(): Boolean = modal && scrimProgress > 0.001f
 
+  /**
+   * Dismiss the sheet in response to a hardware back press, mirroring scrim-tap dismissal: snap to
+   * the closed detent (emitting `onIndexChange` so a controlled `index` stays in sync) when the
+   * scrim is visible and a non-programmatic close detent exists. Returns `true` when the back press
+   * was consumed, `false` otherwise so the caller can fall back to default back handling.
+   */
+  fun requestCloseFromBack(): Boolean {
+    val closeIndex = scrimDismissIndex
+    if (isScrimVisible() && closeIndex != null) {
+      snapToIndex(closeIndex, 0f)
+      return true
+    }
+    return false
+  }
+
   private fun drawScrim(canvas: Canvas) {
     if (!modal || scrimProgress <= 0.001f) {
       return

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetView.kt
@@ -198,17 +198,19 @@ class BottomSheetView(context: Context) : ReactViewGroup(context), LifecycleEven
     )
     dialog.setCancelable(false)
     dialog.window?.let { configureOverlayWindow(it, activity) }
-    // Stay unopinionated about the system back gesture, exactly like the inline
-    // (portal-based) modal, which registers no back handling and leaves it to the
-    // consumer. The dialog is a separate focusable window that would otherwise
-    // consume the back press and dismiss itself, so instead of acting on it we
-    // forward it to the host activity. That runs whatever the consumer wired up
-    // (JS `BackHandler`, React Navigation, …), just as a back press would for an
-    // inline modal.
+    // A visible scrim means the sheet is presented modally, where a scrim tap dismisses it, so a
+    // hardware back should do the same. Unlike the inline (portal-based) modal — which lives in the
+    // host window, so the consumer's back handling can close it — this dialog is a separate,
+    // focusable window that consumes the back press itself; forwarding it to the host activity only
+    // runs React Navigation / JS `BackHandler`, which pops the screen instead of closing the sheet.
+    // So we dismiss the sheet here (host.requestCloseFromBack() mirrors scrim-tap dismissal and
+    // emits onIndexChange to keep a controlled `index` in sync). When there is nothing to dismiss we
+    // stay unopinionated and forward the back press to the host activity, just like an inline modal.
     dialog.onBackPressedDispatcher.addCallback(
       dialog,
       object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
+          if (host.requestCloseFromBack()) return
           (activity as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
         }
       },


### PR DESCRIPTION
## Summary

On Android the native-overlay (`ModalBottomSheet` with `nativeOverlay`) sheet is hosted in a separate `ComponentDialog` window. Its `OnBackPressedCallback` currently forwards the hardware back press to the host activity's `onBackPressedDispatcher`. In a React Navigation (native-stack) app that pops the current screen — or exits the app — instead of closing the sheet.

Unlike the inline (portal-based) modal — which lives in the host window, so a consumer's back handling can intercept and close it — the overlay lives in a separate window, so there is no reliable way for the consumer to close the *sheet* from the forwarded back press.

## Change

`handleOnBackPressed()` now first calls `host.requestCloseFromBack()`:

- It **mirrors scrim-tap dismissal**: when the scrim is visible and a non-programmatic close detent exists, it `snapToIndex(closeIndex, 0f)` (emitting `onIndexChange`, so a controlled `index` stays in sync). It reuses the exact `scrimDismissIndex` + `snapToIndex` path the scrim tap already uses.
- Returns `true` when it consumed the back press.
- When there is nothing to dismiss (no visible scrim / no dismissible detent) it returns `false`, and we **fall back to the previous behavior** — forwarding to the host activity — so the unopinionated path is preserved for those cases.

Scope: Android only (iOS has no hardware back). No JS / public-API changes.

## Notes

- I noticed the existing comment intentionally keeps back handling unopinionated. This change only acts when the sheet is modally presented with a dismissible scrim, and otherwise keeps that forward. Happy to instead gate it behind an explicit prop (e.g. `dismissOnBack`) or surface an `onRequestClose`-style event, if you prefer that design — this PR is a starting point for discussion.
- Verified on a physical Android device in a React Navigation native-stack app: hardware back now closes the overlay sheet instead of popping the screen; a sheet whose close detent is `programmatic` correctly falls through to the previous forwarding behavior.