### PR TITLE
fix(android): native-overlay sheet — restore touch on collapsed children + full-screen sizing

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -110,6 +110,31 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private val contentHeightMarkerLayoutListener =
     View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
 
+  // The sheet children (surface + content wrapper) are laid out by layoutSheetChildren, which
+  // only runs from this host's own onLayout. This host and its container are plain (non-Fabric)
+  // views, so a child that is mounted *after* the host's layout pass — common with data-loaded or
+  // otherwise deferred content — is never sized: it is added at 0×0 and no layout pass re-runs to
+  // fill it. It then draws via overflow (so it looks correct) but has 0×0 native bounds, and
+  // Android hit-testing cannot descend into a zero-bounds view, so scroll and press are dead below
+  // it. Re-assert fillable bounds on any collapsed child before drawing; the container size is
+  // cached from layoutSheetContainer. Only fires while a child is collapsed, so it is a no-op once
+  // the child is filled and for sheets that never hit the timing.
+  private var lastContainerWidth = 0
+  private var lastContainerHeight = 0
+
+  private val fillCollapsedSheetChildrenPreDrawListener =
+    ViewTreeObserver.OnPreDrawListener {
+      if (lastContainerWidth > 0 && lastContainerHeight > 0) {
+        for (i in 0 until sheetContainer.childCount) {
+          val child = sheetContainer.getChildAt(i)
+          if (child.width == 0 || child.height == 0) {
+            child.layout(0, 0, lastContainerWidth, lastContainerHeight)
+          }
+        }
+      }
+      true
+    }
+
   init {
     clipChildren = false
     clipToPadding = false
@@ -169,6 +194,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
+    viewTreeObserver.addOnPreDrawListener(fillCollapsedSheetChildrenPreDrawListener)
     // A re-attach gives us a fresh, live ViewTreeObserver; the previous one was
     // dropped on detach. Resume observing if the initial snap is still pending.
     if (pendingInitialContentDetentSnap) {
@@ -177,6 +203,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   }
 
   override fun onDetachedFromWindow() {
+    viewTreeObserver.removeOnPreDrawListener(fillCollapsedSheetChildrenPreDrawListener)
     // Release the listener from the soon-to-be-replaced observer and clear our
     // references so a later re-attach registers on the new live observer.
     removePendingInitialContentDetentObserver()
@@ -252,6 +279,8 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context) {
   private fun layoutSheetContainer(viewWidth: Int, viewHeight: Int) {
     val maxHeight = resolvedMaxDetentHeight(viewHeight)
     val containerTop = (viewHeight - maxHeight).toInt()
+    lastContainerWidth = viewWidth
+    lastContainerHeight = maxHeight.toInt()
     sheetContainer.layout(0, containerTop, viewWidth, containerTop + maxHeight.toInt())
     layoutSheetChildren(viewWidth, maxHeight.toInt())
   }

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -1,6 +1,6 @@
 import { useState, type ComponentType, type ReactNode } from 'react';
 import type { NativeSyntheticEvent, StyleProp, ViewStyle } from 'react-native';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import {
   useSafeAreaFrame,
   useSafeAreaInsets,
@@ -170,7 +170,15 @@ export const BottomSheet = (props: BottomSheetProps) => {
   const { height: safeAreaFrameHeight } = useSafeAreaFrame();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const insets = useSafeAreaInsets();
-  const hostHeight = usesNativeOverlay ? windowHeight : safeAreaFrameHeight;
+  // On Android the native-overlay dialog is a full-screen edge-to-edge window, so its height is the
+  // safe-area frame. useWindowDimensions reports the layout window, which under edge-to-edge
+  // (react-native-edge-to-edge / Expo default) excludes the system-bar insets — using it here clips
+  // the sheet ~(top+bottom) short so it never reaches under the status bar. iOS keeps
+  // useWindowDimensions (frame == window there).
+  const hostHeight =
+    usesNativeOverlay && Platform.OS !== 'android'
+      ? windowHeight
+      : safeAreaFrameHeight;
   const maxHeight = extendUnderStatusBar ? hostHeight : hostHeight - insets.top;
   const nativeDetents = detents.map((detent) => {
     const programmatic = isDetentProgrammatic(detent);


### PR DESCRIPTION
Closes #48

Two related bugs on Android `nativeOverlay` sheets (New Arch / Fabric, edge-to-edge — the Expo/RN default). Both were diagnosed on a physical device (Galaxy Note 20, One UI). iOS and the in-window provider portal are unaffected by either.

---

## 1. Content is untappable / unscrollable (surface + content wrapper collapse to 0×0)

**Symptom:** the sheet renders and can be dragged/dismissed, but `Pressable`s never fire and scrollables never scroll — independent of the list implementation and of `disableScrollableNegotiation`.

**Cause:** `nativeOverlay` re-roots the content into a separate dialog window whose `BottomSheetHostView` / `sheetContainer` are plain (non-Fabric) views. Their two direct children — the surface and the content wrapper — are sized only by `layoutSheetChildren`, which runs from the host's own `onLayout`. When content mounts **after** that layout pass (common with data-loaded / deferred content), the host — not being Fabric-managed — does not re-run `onLayout`, so those children are added at `0×0` and never sized. They draw via overflow (so the sheet looks correct) but keep `0×0` native bounds, and Android hit-testing cannot descend into a zero-bounds view, so scroll/press die below them. Instrumented: at touch time only the surface + content wrapper are `0×0`; every descendant is correctly sized, and the hit-test stops at the collapsed wrapper. A corrective layout fires exactly once per child and never again — i.e. they are never laid out, not re-zeroed. (`RootNodeKind` is not the cause — removing it doesn't help; and the `ae18043` explicit-size wrapper doesn't take effect in this timing since the wrapper is never laid out.)

**Fix:** re-assert fillable bounds on any collapsed sheet child in a pre-draw pass on the host. No-op once filled and for sheets that never hit the timing. (`BottomSheetHostView.kt`)

## 2. Full-height sheet only opens ~70-80%, never reaching under the status bar

**Symptom:** a `[0, '100%']`-style sheet opens short on Android `nativeOverlay`, leaving a gap between the sheet top and the status bar.

**Cause:** the `nativeOverlay` dialog is a full-screen edge-to-edge window, but `hostHeight` is taken from `useWindowDimensions`. Under edge-to-edge (`react-native-edge-to-edge`, the Expo/RN default), that reports the layout window **minus** the system-bar insets. Measured on device (dp): `useWindowDimensions().height = 808.76`, `useSafeAreaFrame().height = 882.29` (= screen), `insets.top = 25.52`, `insets.bottom = 48` — i.e. `window = screen − top − bottom`. So `maxHeight = hostHeight − insets.top = 808.76 − 25.52 = 783`, and the sheet is clamped to `783` of an `882` dialog — short by ~`(top + bottom)`. The in-window path uses the frame (`882`) and opens correctly, which confirms the delta is purely the height source.

**Fix:** on Android, size the full-screen native-overlay dialog from the safe-area frame (the true full-screen height) instead of `useWindowDimensions`. iOS is unchanged (frame == window there). (`src/BottomSheet.tsx`; with `maxHeight = 882 − 25.52 = 856.5` the sheet now reaches under the status bar.)

---

Verified on device: both fixes confirmed (taps + scroll work; full-height sheets open under the status bar). Happy to split into two PRs if preferred.
