### PR TITLE
feat: add percentage detents and validate sheet props

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -31,6 +31,7 @@ import kotlin.math.roundToInt
 
 private enum class DetentKind {
   POINTS,
+  PERCENTAGE,
   CONTENT,
 }
 
@@ -146,7 +147,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context), NestedScr
   private var pendingInitialContentDetentFrames = 0
 
   private val contentHeightMarkerLayoutListener =
-    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> refreshDetentsFromLayout() }
+    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+      refreshDetentsFromLayout()
+    }
 
   init {
     clipChildren = false
@@ -353,17 +356,19 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context), NestedScr
   // MARK: - Prop setters
 
   fun setDetents(raw: List<Map<String, Any>>) {
-    rawDetentSpecs =
-      raw.mapNotNull { dict ->
-        val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
-        val kind =
-          when ((dict["kind"] as? String)?.lowercase()) {
-            "content" -> DetentKind.CONTENT
-            else -> DetentKind.POINTS
-          }
-        val programmatic = dict["programmatic"] as? Boolean ?: false
-        RawDetentSpec(value = (value * density).toFloat(), kind = kind, programmatic = programmatic)
-      }
+    rawDetentSpecs = raw.mapNotNull { dict ->
+      val value = (dict["value"] as? Number)?.toDouble() ?: return@mapNotNull null
+      val kind =
+        when (dict["kind"] as? String) {
+          "content" -> DetentKind.CONTENT
+          "percentage" -> DetentKind.PERCENTAGE
+          else -> DetentKind.POINTS
+        }
+      val programmatic = dict["programmatic"] as? Boolean ?: false
+      val nativeValue =
+        if (kind == DetentKind.POINTS) (value * density).toFloat() else value.toFloat()
+      RawDetentSpec(value = nativeValue, kind = kind, programmatic = programmatic)
+    }
     refreshDetentsFromLayout()
   }
 
@@ -428,6 +433,7 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context), NestedScr
       val height =
         when (spec.kind) {
           DetentKind.POINTS -> spec.value
+          DetentKind.PERCENTAGE -> maxHeight * spec.value
           DetentKind.CONTENT ->
             measuredContentHeight ?: unresolvedContentDetentHeight(index, maxHeight)
         }.coerceIn(0f, maxHeight)
@@ -444,9 +450,16 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context), NestedScr
   }
 
   private fun unresolvedContentDetentHeight(index: Int, maxHeight: Float): Float {
-    val nextPointHeight =
-      rawDetentSpecs.drop(index + 1).firstOrNull { it.kind == DetentKind.POINTS }?.value
-    return (nextPointHeight ?: maxHeight).coerceIn(0f, maxHeight)
+    val nextBound =
+      rawDetentSpecs.drop(index + 1).firstOrNull { it.kind != DetentKind.CONTENT }
+        ?: return maxHeight
+    val nextBoundHeight =
+      when (nextBound.kind) {
+        DetentKind.POINTS -> nextBound.value
+        DetentKind.PERCENTAGE -> maxHeight * nextBound.value
+        DetentKind.CONTENT -> maxHeight
+      }
+    return nextBoundHeight.coerceIn(0f, maxHeight)
   }
 
   private fun refreshDetentsFromLayout() {
@@ -591,23 +604,22 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context), NestedScr
     if (!observer.isAlive) return
 
     pendingInitialContentDetentFrames = 0
-    val listener =
-      ViewTreeObserver.OnPreDrawListener {
-        refreshContentHeightMarker()
-        refreshDetentsFromLayout()
-        // refreshDetentsFromLayout() completes and stops observing via
-        // trySnapPendingInitialContentDetent() once the target is measurable.
-        // If it is still pending, this frame was unproductive: bound how many
-        // such frames we spend so a content detent that never becomes
-        // measurable cannot keep us redrawing forever.
-        if (
-          pendingInitialContentDetentSnap &&
-            ++pendingInitialContentDetentFrames >= MAX_PENDING_INITIAL_CONTENT_DETENT_FRAMES
-        ) {
-          removePendingInitialContentDetentObserver()
-        }
-        true
+    val listener = ViewTreeObserver.OnPreDrawListener {
+      refreshContentHeightMarker()
+      refreshDetentsFromLayout()
+      // refreshDetentsFromLayout() completes and stops observing via
+      // trySnapPendingInitialContentDetent() once the target is measurable.
+      // If it is still pending, this frame was unproductive: bound how many
+      // such frames we spend so a content detent that never becomes
+      // measurable cannot keep us redrawing forever.
+      if (
+        pendingInitialContentDetentSnap &&
+          ++pendingInitialContentDetentFrames >= MAX_PENDING_INITIAL_CONTENT_DETENT_FRAMES
+      ) {
+        removePendingInitialContentDetentObserver()
       }
+      true
+    }
 
     // Keep the exact observer instance used for registration. Android can
     // replace a ViewTreeObserver across attach/detach boundaries, and listeners

--- a/docs/content/detents-and-index.mdx
+++ b/docs/content/detents-and-index.mdx
@@ -4,17 +4,35 @@ title: Detents and index
 
 # Detents and index
 
-Detents are the points to which the sheet snaps. Each detent is either a number
-(a fixed height in pixels) or `'content'` (the sheet’s content height, capped by
-the available screen height). The default detents are `[0, 'content']`. Pass
-detents in ascending order, from shortest to tallest. Fixed detents can be
-taller than the measured content height, so `[0, 'content', 600]` lets a compact
-content-sized sheet expand to a larger surface.
+Detents are the heights to which the sheet snaps. Each detent is a number (a
+fixed height in React Native density-independent layout units—points on iOS and
+dp on Android), a percentage string such as `'30%'`, or `'content'` (the
+measured content height, capped by the available sheet height). The default
+detents are `[0, 'content']`.
 
-Sheet children are laid out in a flex container. For a full-height
-sheet, apply `flex: 1` to your content and use the `'content'` detent.
-`surface` is sized by the library, so `flex: 1` only ever belongs on your
-content, never on the surface:
+For example, `[0, 'content']` creates a content-sized sheet, `[0, 300]` keeps
+the open height fixed, and `['0%', '30%', '80%']` creates responsive heights.
+
+Percentage values from `0%` through `100%`, including decimals such as `12.5%`,
+resolve against the available sheet height and update when that height changes.
+The percentage syntax is unsigned and does not allow whitespace, so values such
+as `'-10%'` are invalid.
+
+`detents` must contain at least one item. Numeric detents must be finite and
+non-negative; the library throws an `Error` for values such as `-10`, `NaN`, or
+`Infinity` instead of correcting them. A numeric detent may be taller than the
+measured content or exceed the available height; native layout caps its resolved
+height to the available geometry.
+
+Pass detents in ascending order, from shortest to tallest. Detent forms can be
+mixed, but they must remain ordered by their resolved heights at every layout
+size your app supports. The library validates the resolved order during native
+layout.
+
+Sheet children are laid out in a flex container. For a full-height sheet, apply
+`flex: 1` to your content and use the `'content'` detent. `surface` is sized by
+the library, so `flex: 1` only ever belongs on your content, never on the
+surface:
 
 ```tsx
 <BottomSheet
@@ -46,8 +64,11 @@ screen height:
 
 ## Index events
 
-The `index` prop is a zero-based index into the `detents` array.
-`onIndexChange` and `onSettle` have different responsibilities:
+The `index` prop must be a finite, zero-based integer in the range
+`0..(detents.length - 1)`. Invalid indices and empty `detents` arrays throw an
+`Error` synchronously in JavaScript for both `BottomSheet` and
+`ModalBottomSheet`. `onIndexChange` and `onSettle` have different
+responsibilities:
 
 - `onIndexChange` fires when a user-triggered snap is _initiated_: the
   moment a drag commits to a detent, before the animation settles. It does not
@@ -65,7 +86,7 @@ const [index, setIndex] = useState(0);
 
 ```tsx
 <BottomSheet // Or `ModalBottomSheet`.
-  detents={[0, 300, 'content']} // Collapsed, 300 px, content height.
+  detents={[0, 300, 600]} // Collapsed, 300 layout units, 600 layout units.
   index={index}
   onIndexChange={setIndex} // Fires when a drag commits; keep state in sync.
   surface={/* ... */}
@@ -78,7 +99,9 @@ const [index, setIndex] = useState(0);
 ```
 
 Detents can also change over time. When you update `detents`, the sheet keeps
-the current index and animates to the updated detent height when needed.
+the current index and animates to the updated detent height when needed. If an
+update shortens the array, set a matching in-range `index` in the same render;
+the library does not clamp a now-out-of-range index.
 
 ## Programmatic-only detents
 
@@ -89,7 +112,7 @@ detent is programmatic-only, tapping the scrim does not dismiss the sheet.
 
 ```tsx
 <BottomSheet
-  detents={[0, programmatic(300), 'content']}
+  detents={[0, programmatic(300), 600]}
   index={index}
   onIndexChange={setIndex}
   surface={/* ... */}

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -108,7 +108,7 @@ export default function RootLayout() {
             />
             <Stack.Screen
               name="invalid-detents"
-              options={{ title: 'Invalid detents', headerShown: false }}
+              options={{ title: 'Invalid props', headerShown: false }}
             />
             <Stack.Screen
               name="scrollable-negotiation"
@@ -121,6 +121,13 @@ export default function RootLayout() {
               name="programmatic-detent-drag"
               options={{
                 title: 'Programmatic detent drag',
+                headerShown: false,
+              }}
+            />
+            <Stack.Screen
+              name="percentage-detents"
+              options={{
+                title: 'Numeric and percentage detents',
                 headerShown: false,
               }}
             />

--- a/example/app/percentage-detents.tsx
+++ b/example/app/percentage-detents.tsx
@@ -1,0 +1,1 @@
+export { PercentageDetentsScreen as default } from '../src/demos/PercentageDetentsScreen';

--- a/example/src/demoCases.tsx
+++ b/example/src/demoCases.tsx
@@ -18,6 +18,7 @@ export type CaseKey =
   | 'invalid-detents'
   | 'scrollable-negotiation'
   | 'programmatic-detent-drag'
+  | 'percentage-detents'
   | 'dynamic-detents'
   | 'dynamic-content-height'
   | 'snap-callbacks'
@@ -115,7 +116,7 @@ export const DEMO_CASES: DemoCase[] = [
   },
   {
     key: 'invalid-detents',
-    title: 'Invalid detents',
+    title: 'Invalid props',
     href: '/invalid-detents',
     throws: true,
   },
@@ -128,6 +129,11 @@ export const DEMO_CASES: DemoCase[] = [
     key: 'programmatic-detent-drag',
     title: 'Programmatic detent drag',
     href: '/programmatic-detent-drag',
+  },
+  {
+    key: 'percentage-detents',
+    title: 'Numeric and percentage detents',
+    href: '/percentage-detents',
   },
   {
     key: 'dynamic-detents',

--- a/example/src/demos/DynamicDetentsScreen.tsx
+++ b/example/src/demos/DynamicDetentsScreen.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import { BottomSheet } from '@swmansion/react-native-bottom-sheet';
+import { BottomSheet, type Detent } from '@swmansion/react-native-bottom-sheet';
 
 import {
   DemoScreen,
@@ -12,12 +12,23 @@ import {
 export const DynamicDetentsScreen = () => {
   const [index, setIndex] = useState(0);
   const [middleDetent, setMiddleDetent] = useState(200);
+  const [usesShortDetents, setUsesShortDetents] = useState(false);
   const [position, setPosition] = useState(0);
   const sheetBottomPadding = useSheetBottomPadding(0);
-  const detents = useMemo(
-    () => [0, middleDetent, 'content'] as const,
-    [middleDetent]
+  const detents = useMemo<Detent[]>(
+    () => (usesShortDetents ? [0, middleDetent] : [0, middleDetent, 'content']),
+    [middleDetent, usesShortDetents]
   );
+
+  const shortenDetents = () => {
+    setIndex(1);
+    setUsesShortDetents(true);
+  };
+
+  const restoreContentDetent = () => {
+    setIndex(2);
+    setUsesShortDetents(false);
+  };
 
   return (
     <DemoScreen
@@ -57,7 +68,7 @@ export const DynamicDetentsScreen = () => {
     >
       <View style={{ gap: 12 }}>
         <Button title="Open at index 1" onPress={() => setIndex(1)} />
-        <Button title="Expand to content" onPress={() => setIndex(2)} />
+        <Button title="Expand to content" onPress={restoreContentDetent} />
         <Button title="Collapse" onPress={() => setIndex(0)} />
       </View>
       <View style={{ gap: 12 }}>
@@ -69,6 +80,14 @@ export const DynamicDetentsScreen = () => {
           title="Use 300pt middle detent"
           onPress={() => setMiddleDetent(300)}
         />
+        <Button
+          title="Shorten detents and select last index"
+          onPress={shortenDetents}
+        />
+        <Button
+          title="Restore content detent and select it"
+          onPress={restoreContentDetent}
+        />
       </View>
       <View
         style={{
@@ -79,9 +98,15 @@ export const DynamicDetentsScreen = () => {
         }}
       >
         <Text style={{ fontWeight: '600' }}>Current state</Text>
-        <Text>detents: [{`0, ${middleDetent}, 'content'`}]</Text>
+        <Text>
+          detents: [0, {middleDetent}
+          {usesShortDetents ? '' : ", 'content'"}]
+        </Text>
         <Text>index: {index}</Text>
         <Text>position: {position.toFixed(0)}pt</Text>
+        <Text>
+          Shortening and restoring update detents and index in the same render.
+        </Text>
       </View>
     </DemoScreen>
   );

--- a/example/src/demos/InvalidDetentsScreen.tsx
+++ b/example/src/demos/InvalidDetentsScreen.tsx
@@ -1,71 +1,155 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { BottomSheet } from '@swmansion/react-native-bottom-sheet';
+import { Component, useState, type ReactNode } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { BottomSheet, type Detent } from '@swmansion/react-native-bottom-sheet';
 
 import { DemoScreen, SheetBackground } from '../demoShared';
 
 const INVALID_DETENTS_CONTENT_HEIGHT = 160;
 
+type ValidationCase = Readonly<{
+  label: string;
+  detents: Detent[];
+  index: number;
+}>;
+
+const VALIDATION_CASES: ValidationCase[] = [
+  { label: 'index: 1.5', detents: [0, 'content'], index: 1.5 },
+  {
+    label: 'index equal to detents.length',
+    detents: [0, 'content'],
+    index: 2,
+  },
+  { label: 'empty detents', detents: [], index: 0 },
+  { label: 'numeric detent: -10', detents: [0, -10], index: 0 },
+  { label: "percentage detent: '-10%'", detents: [0, '-10%'], index: 0 },
+  {
+    label: 'native ascending-order validation',
+    detents: [360, 120, 'content'],
+    index: 1,
+  },
+];
+
+type ValidationErrorBoundaryState = { error: string | null };
+
+class ValidationErrorBoundary extends Component<
+  { children: ReactNode },
+  ValidationErrorBoundaryState
+> {
+  state: ValidationErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+
+  render() {
+    if (this.state.error !== null) {
+      return (
+        <View style={styles.errorCard}>
+          <Text style={styles.errorTitle}>Caught JavaScript Error</Text>
+          <Text selectable>{this.state.error}</Text>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
 export const InvalidDetentsScreen = () => {
+  const [caseIndex, setCaseIndex] = useState(0);
+  const validationCase = VALIDATION_CASES[caseIndex]!;
+
   return (
     <DemoScreen
-      title="Invalid detents"
+      title="Invalid props"
       sheet={
-        <BottomSheet
-          detents={[360, 120, 'content']}
-          index={1}
-          surface={<SheetBackground style={StyleSheet.absoluteFill} />}
-        >
-          <View>
-            <View
-              style={{
-                alignItems: 'center',
-                paddingTop: 8,
-                paddingBottom: 4,
-              }}
-            >
+        <ValidationErrorBoundary key={caseIndex}>
+          <BottomSheet
+            detents={validationCase.detents}
+            index={validationCase.index}
+            surface={<SheetBackground style={StyleSheet.absoluteFill} />}
+          >
+            <View>
               <View
                 style={{
-                  width: 36,
-                  height: 4,
-                  borderRadius: 2,
-                  backgroundColor: '#ddd',
+                  alignItems: 'center',
+                  paddingTop: 8,
+                  paddingBottom: 4,
                 }}
-              />
+              >
+                <View
+                  style={{
+                    width: 36,
+                    height: 4,
+                    borderRadius: 2,
+                    backgroundColor: '#ddd',
+                  }}
+                />
+              </View>
+              <View
+                style={{
+                  height: 64,
+                  justifyContent: 'center',
+                  paddingHorizontal: 20,
+                  borderBottomWidth: 1,
+                  borderBottomColor: '#eee',
+                }}
+              >
+                <Text style={{ fontSize: 20, fontWeight: 'bold' }}>
+                  Invalid props
+                </Text>
+              </View>
             </View>
             <View
               style={{
-                height: 64,
-                justifyContent: 'center',
+                height: INVALID_DETENTS_CONTENT_HEIGHT,
                 paddingHorizontal: 20,
-                borderBottomWidth: 1,
-                borderBottomColor: '#eee',
+                justifyContent: 'center',
+                gap: 12,
               }}
             >
-              <Text style={{ fontSize: 20, fontWeight: 'bold' }}>
-                Invalid detents
+              <Text style={{ fontSize: 18, fontWeight: '600' }}>
+                This sheet should not be allowed.
+              </Text>
+              <Text style={{ fontSize: 15, lineHeight: 22, color: '#555' }}>
+                The final case reaches native layout to confirm that resolved
+                detent ordering is still validated there.
               </Text>
             </View>
-          </View>
-          <View
-            style={{
-              height: INVALID_DETENTS_CONTENT_HEIGHT,
-              paddingHorizontal: 20,
-              justifyContent: 'center',
-              gap: 12,
-            }}
-          >
-            <Text style={{ fontSize: 18, fontWeight: '600' }}>
-              This sheet should not be allowed.
-            </Text>
-            <Text style={{ fontSize: 15, lineHeight: 22, color: '#555' }}>
-              The 120pt detent comes after a 360pt detent, so the native view
-              should report an ascending-order detent error.
-            </Text>
-          </View>
-        </BottomSheet>
+          </BottomSheet>
+        </ValidationErrorBoundary>
       }
     >
-      <Text>detents: [{`360, 120, 'content'`}]</Text>
+      <Text>
+        Case {caseIndex + 1} of {VALIDATION_CASES.length}:{' '}
+        {validationCase.label}
+      </Text>
+      <Button
+        title="Show next invalid case"
+        onPress={() =>
+          setCaseIndex((current) => (current + 1) % VALIDATION_CASES.length)
+        }
+      />
+      <Text>
+        Static index and detent errors are caught above the native view. The
+        final case intentionally exercises native ascending-order validation.
+      </Text>
     </DemoScreen>
   );
 };
+
+const styles = StyleSheet.create({
+  errorCard: {
+    margin: 20,
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#d11',
+    backgroundColor: '#fff4f4',
+    gap: 8,
+  },
+  errorTitle: {
+    color: '#d11',
+    fontWeight: '700',
+  },
+});

--- a/example/src/demos/PercentageDetentsScreen.tsx
+++ b/example/src/demos/PercentageDetentsScreen.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { BottomSheet, type Detent } from '@swmansion/react-native-bottom-sheet';
+
+import {
+  DemoScreen,
+  SheetBackground,
+  SheetHeader,
+  useSheetBottomPadding,
+} from '../demoShared';
+
+const DETENTS: Detent[] = ['0%', 80, '45%', '100%'];
+
+export const PercentageDetentsScreen = () => {
+  const [index, setIndex] = useState(0);
+  const [position, setPosition] = useState(0);
+  const sheetBottomPadding = useSheetBottomPadding(0);
+
+  return (
+    <DemoScreen
+      title="Numeric and percentage detents"
+      sheet={
+        <BottomSheet
+          detents={DETENTS}
+          index={index}
+          onIndexChange={setIndex}
+          onPositionChange={(event) => setPosition(event.nativeEvent.position)}
+          surface={<SheetBackground style={StyleSheet.absoluteFill} />}
+        >
+          <SheetHeader title="Responsive detents" onClose={() => setIndex(0)} />
+          <View
+            style={[
+              styles.sheetBody,
+              {
+                height: 680 + sheetBottomPadding,
+                paddingBottom: sheetBottomPadding,
+              },
+            ]}
+          >
+            <Text style={styles.heading}>Resize the app window</Text>
+            <Text style={styles.body}>
+              The 80pt detent stays fixed. The 45% and 100% detents are
+              recalculated from the usable native height, including when the app
+              window changes size.
+            </Text>
+          </View>
+        </BottomSheet>
+      }
+    >
+      <View style={styles.controls}>
+        <Button title="Collapse to 0% (0)" onPress={() => setIndex(0)} />
+        <Button title="Open to 80pt (1)" onPress={() => setIndex(1)} />
+        <Button title="Open to 45% (2)" onPress={() => setIndex(2)} />
+        <Button title="Open to 100% (3)" onPress={() => setIndex(3)} />
+      </View>
+      <View style={styles.card}>
+        <Text style={styles.cardLabel}>Current state</Text>
+        <Text>detents: ['0%', 80, '45%', '100%']</Text>
+        <Text>index: {index}</Text>
+        <Text>position: {position.toFixed(1)}pt</Text>
+      </View>
+    </DemoScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  controls: { gap: 12 },
+  sheetBody: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    gap: 12,
+  },
+  heading: { fontSize: 18, fontWeight: '600' },
+  body: { fontSize: 15, lineHeight: 22, color: '#555' },
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: '#f3f3f3',
+    gap: 6,
+  },
+  cardLabel: { fontWeight: '600' },
+});

--- a/ios/BottomSheetComponentView.mm
+++ b/ios/BottomSheetComponentView.mm
@@ -96,7 +96,7 @@ using namespace facebook::react;
     for (const auto &detent : newViewProps.detents) {
       [detentsArray addObject:@{
         @"value": @(detent.value),
-        @"kind": detent.kind == "content" ? @"content" : @"points",
+        @"kind": RCTNSStringFromString(detent.kind),
         @"programmatic": @(detent.programmatic),
       }];
     }

--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -20,6 +20,7 @@ private struct DetentSpec: Equatable {
 
 private enum DetentKind {
   case points
+  case percentage
   case content
 }
 
@@ -356,8 +357,17 @@ public final class BottomSheetHostingView: UIView {
       guard let value = dict["value"] as? Double ?? (dict["value"] as? NSNumber)?.doubleValue else {
         return nil
       }
-      let kindString = (dict["kind"] as? String) ?? ((dict["kind"] as? NSString) as String?) ?? "points"
-      let kind: DetentKind = kindString == "content" ? .content : .points
+      let kindString =
+        (dict["kind"] as? String) ?? ((dict["kind"] as? NSString) as String?) ?? "points"
+      let kind: DetentKind
+      switch kindString {
+      case "content":
+        kind = .content
+      case "percentage":
+        kind = .percentage
+      default:
+        kind = .points
+      }
       let programmatic = (dict["programmatic"] as? Bool) ?? (dict["programmatic"] as? NSNumber)?.boolValue ?? false
       return RawDetentSpec(value: CGFloat(value), kind: kind, programmatic: programmatic)
     }
@@ -1296,6 +1306,8 @@ public final class BottomSheetHostingView: UIView {
       switch spec.kind {
       case .points:
         height = spec.value
+      case .percentage:
+        height = maxHeight * spec.value
       case .content:
         height =
           measuredContentHeight ?? unresolvedContentDetentHeight(after: index, maxHeight: maxHeight)
@@ -1321,10 +1333,17 @@ public final class BottomSheetHostingView: UIView {
     guard index + 1 < rawDetentSpecs.count else {
       return maxHeight
     }
-    let nextPointHeight = rawDetentSpecs[(index + 1)...]
-      .first { $0.kind == .points }
-      .map(\.value)
-    return min(max(0, nextPointHeight ?? maxHeight), maxHeight)
+    for spec in rawDetentSpecs[(index + 1)...] {
+      switch spec.kind {
+      case .points:
+        return min(max(0, spec.value), maxHeight)
+      case .percentage:
+        return min(max(0, maxHeight * spec.value), maxHeight)
+      case .content:
+        continue
+      }
+    }
+    return maxHeight
   }
 
   private func refreshDetentsFromLayout() {
@@ -1513,7 +1532,7 @@ public final class BottomSheetHostingView: UIView {
       return false
     }
     switch rawDetentSpecs[index].kind {
-    case .points:
+    case .points, .percentage:
       return false
     case .content:
       return validContentHeight == nil

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -7,7 +7,12 @@ import BottomSheetNativeView, {
 } from './BottomSheetNativeComponent';
 import BottomSheetSurfaceNativeComponent from './BottomSheetSurfaceNativeComponent';
 import { Portal } from './BottomSheetProvider';
-import { type Detent } from './bottomSheetUtils';
+import {
+  type Detent,
+  isNormalizedDetentClosed,
+  normalizeDetent,
+  validateIndex,
+} from './bottomSheetUtils';
 export type { Detent, DetentValue } from './bottomSheetUtils';
 export { programmatic } from './bottomSheetUtils';
 
@@ -71,12 +76,17 @@ export interface BottomSheetProps {
   style?: StyleProp<ViewStyle>;
   /**
    * Snap points for the sheet, in ascending order by height. Defaults to
-   * `[0, 'content']`. Fixed detents may be taller than the measured content
-   * height, so `[0, 'content', 600]` is valid when the content is shorter than
-   * 600pt.
+   * `[0, 'content']` and must contain at least one value. Numbers must be finite
+   * and non-negative. Percentage strings must be unsigned values from `0%`
+   * through `100%` and resolve against the native usable height. Fixed detents
+   * may be taller than the measured content or available height; native layout
+   * caps them to the available geometry.
    */
   detents?: Detent[];
-  /** Zero-based index into `detents`. */
+  /**
+   * Finite, zero-based integer in `0..(detents.length - 1)`. When shortening
+   * `detents`, update `index` to remain in range in the same render.
+   */
   index: number;
   /** Whether the sheet should animate in on first layout. */
   animateIn?: boolean;
@@ -211,38 +221,21 @@ export const BottomSheet = (props: BottomSheetProps) => {
   // only size the native-overlay host for the first frame, before the overlay
   // window reports its measured geometry.
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
-  const nativeDetents = detents.map((detent) => {
-    const programmatic = isDetentProgrammatic(detent);
-    const value = resolveDetentValue(detent);
+  // Percentage detents stay as unitless ratios and are resolved against the
+  // current native cap whenever detents are refreshed. Point detents retain
+  // their requested height; native layout clamps both kinds to that cap.
+  validateIndex(index, detents.length);
+  const normalizedDetents = detents.map(normalizeDetent);
 
-    if (value === 'content') {
-      return {
-        value: 0,
-        kind: 'content',
-        programmatic,
-      };
-    }
-
-    return {
-      // Detents are clamped natively against the natively computed cap;
-      // pre-clamping here against a JS-estimated height would reintroduce the
-      // estimate as a ceiling.
-      value: Math.max(0, value),
-      kind: 'points',
-      programmatic,
-    };
-  });
-
-  const clampedIndex = Math.max(0, Math.min(index, nativeDetents.length - 1));
-  const selectedDetentValue = detents[clampedIndex]
-    ? resolveDetentValue(detents[clampedIndex])
-    : 0;
-  const isCollapsed = selectedDetentValue === 0;
+  const selectedNormalizedDetent = normalizedDetents[index]!;
+  const isSheetClosed = isNormalizedDetentClosed(selectedNormalizedDetent);
   // Default the scrim opacity per detent: transparent at any closed detent,
   // fully opaque at every open one.
-  const resolvedScrimOpacity =
+  const resolvedScrimOpacities =
     scrimOpacities ??
-    detents.map((detent) => (resolveDetentValue(detent) === 0 ? 0 : 1));
+    normalizedDetents.map((detent) =>
+      isNormalizedDetentClosed(detent) ? 0 : 1
+    );
   const handleIndexChange = (event: { nativeEvent: { index: number } }) => {
     onIndexChange?.(event.nativeEvent.index);
   };
@@ -268,7 +261,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
   const sheet = (
     <View
       style={StyleSheet.absoluteFill}
-      pointerEvents={modal ? (isCollapsed ? 'none' : 'auto') : 'box-none'}
+      pointerEvents={modal ? (isSheetClosed ? 'none' : 'auto') : 'box-none'}
     >
       <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
         <NativeView
@@ -292,7 +285,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
               : StyleSheet.absoluteFill,
             style,
           ]}
-          detents={nativeDetents}
+          detents={normalizedDetents}
           extendUnderStatusBar={extendUnderStatusBar}
           index={index}
           animateIn={animateIn}
@@ -306,7 +299,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
             SCROLLABLE_NEGOTIATION_LEVEL[resolvedCollapseNegotiation]
           }
           scrimColor={scrimColor}
-          scrimOpacities={resolvedScrimOpacity}
+          scrimOpacities={resolvedScrimOpacities}
           onIndexChange={handleIndexChange}
           onSettle={handleSettle}
           onPositionChange={onPositionChange}
@@ -350,20 +343,6 @@ export const BottomSheet = (props: BottomSheetProps) => {
 
   return sheet;
 };
-
-function isDetentProgrammatic(detent: Detent): boolean {
-  if (typeof detent === 'object' && detent !== null) {
-    return detent.programmatic === true;
-  }
-  return false;
-}
-
-function resolveDetentValue(detent: Detent) {
-  if (typeof detent === 'object' && detent !== null) {
-    return detent.value;
-  }
-  return detent;
-}
 
 const styles = StyleSheet.create({
   contentWrapper: { flex: 1 },

--- a/src/bottomSheetUtils.ts
+++ b/src/bottomSheetUtils.ts
@@ -1,5 +1,8 @@
-/** A detent value in points, or `'content'` to size to the measured content height. */
-export type DetentValue = number | 'content';
+/**
+ * A finite, non-negative height in points, an unsigned percentage from `0%`
+ * through `100%`, or `'content'` for the measured content height.
+ */
+export type DetentValue = number | `${number}%` | 'content';
 
 /** A draggable detent or an object form that can mark a detent as programmatic-only. */
 export type Detent =
@@ -22,6 +25,98 @@ export const isDetentProgrammatic = (detent: Detent): boolean => {
     return detent.programmatic === true;
   }
   return false;
+};
+
+type NormalizedDetent = Readonly<{
+  value: number;
+  kind: 'points' | 'percentage' | 'content';
+  programmatic: boolean;
+}>;
+
+const PERCENTAGE_PATTERN = /^\d+(?:\.\d+)?%$/;
+
+const invalidPercentageError = (value: string, index: number) =>
+  new Error(
+    `Invalid bottom sheet detent at index ${index}: \`${value}\` is not a valid percentage. Expected an unsigned integer or decimal from 0% through 100%, without whitespace.`
+  );
+
+const invalidPointDetentError = (value: number, index: number) =>
+  new Error(
+    `Invalid bottom sheet detent at index ${index}: received ${String(value)}. Expected a finite, non-negative number.`
+  );
+
+/** Parses a percentage detent into a unitless ratio for native resolution. */
+const parseDetentPercentage = (value: string, index: number) => {
+  if (!PERCENTAGE_PATTERN.test(value)) {
+    throw invalidPercentageError(value, index);
+  }
+
+  const percentage = Number(value.slice(0, -1));
+  if (!Number.isFinite(percentage) || percentage < 0 || percentage > 100) {
+    throw invalidPercentageError(value, index);
+  }
+
+  return percentage / 100;
+};
+
+/** Serializes a public detent into the shape consumed by the native views. */
+export const normalizeDetent = (
+  detent: Detent,
+  index: number
+): NormalizedDetent => {
+  const value = detentValue(detent);
+  const isProgrammatic = isDetentProgrammatic(detent);
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) {
+      throw invalidPointDetentError(value, index);
+    }
+
+    return {
+      value,
+      kind: 'points',
+      programmatic: isProgrammatic,
+    };
+  }
+
+  if (value === 'content') {
+    return {
+      value: 0,
+      kind: 'content',
+      programmatic: isProgrammatic,
+    };
+  }
+
+  return {
+    value: parseDetentPercentage(value, index),
+    kind: 'percentage',
+    programmatic: isProgrammatic,
+  };
+};
+
+/** Whether a normalized detent represents a fully closed sheet. */
+export const isNormalizedDetentClosed = (detent: NormalizedDetent) =>
+  detent.kind !== 'content' && detent.value === 0;
+
+/** Validates a controlled index before props are passed to the native view. */
+export const validateIndex = (index: number, detentCount: number) => {
+  if (detentCount === 0) {
+    throw new Error(
+      'Invalid bottom sheet detents: received an empty array. Expected at least one detent.'
+    );
+  }
+
+  if (!Number.isFinite(index) || !Number.isInteger(index)) {
+    throw new Error(
+      `Invalid bottom sheet index: received ${String(index)}. Expected a finite integer from 0 through ${detentCount - 1}.`
+    );
+  }
+
+  if (index < 0 || index >= detentCount) {
+    throw new Error(
+      `Invalid bottom sheet index: received ${String(index)}. Expected a value from 0 through ${detentCount - 1}.`
+    );
+  }
 };
 
 const VELOCITY_THRESHOLD = 800;
@@ -63,22 +158,4 @@ export const findSnapTarget = (
     }
   }
   return targetIndex;
-};
-
-export const resolveDetent = (
-  detent: Detent,
-  contentHeight: number,
-  maxHeight: number
-) => {
-  const detentValueInput = detentValue(detent);
-  if (typeof detentValueInput === 'number') return detentValueInput;
-  if (detentValueInput === 'content') {
-    return contentHeight > 0 ? Math.min(contentHeight, maxHeight) : maxHeight;
-  }
-  throw new Error(`Invalid detent: \`${detentValueInput}\`.`);
-};
-
-export const clampIndex = (index: number, detentCount: number) => {
-  if (detentCount <= 0) return 0;
-  return Math.min(Math.max(index, 0), detentCount - 1);
 };


### PR DESCRIPTION
Adds responsive percentage-based detents, such as '45%' and '100%', alongside existing numeric and 'content' detents.
  Percentages are resolved natively against the available sheet height and update automatically when the layout changes on both
  iOS and Android.

  This also introduces stricter prop validation:

  - Detents must be non-empty, finite, non-negative, and use valid 0%–100% percentage syntax.
  - index must be a finite integer within the detents array.
  - Invalid values now throw descriptive JavaScript errors instead of being silently clamped.
  - Native resolved-order validation remains in place.

  Documentation and example screens were expanded to cover percentage detents, invalid props, and safely updating the index when changing the detents array.