### PR TITLE
fix(ios): hit-test nested scrollables from the touch-down point instead of the post-threshold pan location

### DIFF
--- a/ios/BottomSheetHostingView.swift
+++ b/ios/BottomSheetHostingView.swift
@@ -177,6 +177,7 @@ public final class BottomSheetHostingView: UIView {
   private var isPanning = false
   private var lastReportedInvalidDetentMessage: String?
   private var panStartingIndex: Int?
+  private var initialTouchLocation: CGPoint?
   private var activeDragRange: (minTy: CGFloat, maxTy: CGFloat)?
   private var activeDragDetentSpecs: [DetentSpec]?
   private var activeScrollViewStates: [ActiveScrollViewState] = []
@@ -881,7 +882,7 @@ public final class BottomSheetHostingView: UIView {
       scrollViewOwnsLowerBoundary = false
       activeScrollableNegotiationLevel = negotiationLevel(forVerticalVelocity: gesture.velocity(in: self).y)
 
-      let locationInContainer = gesture.location(in: sheetContainer)
+      let locationInContainer = initialTouchLocation ?? gesture.location(in: sheetContainer)
       activeScrollViewStates = scrollableAncestorChain(containing: locationInContainer).map {
         ActiveScrollViewState(scrollView: $0.scrollView, inverted: $0.inverted)
       }
@@ -1227,7 +1228,7 @@ public final class BottomSheetHostingView: UIView {
     let candidates = snapCandidateIndices(including: targetIndex)
     guard candidates.count > 1 else { return false }
 
-    let locationInContainer = panGesture.location(in: sheetContainer)
+    let locationInContainer = initialTouchLocation ?? panGesture.location(in: sheetContainer)
     let scrollableChain = scrollableAncestorChain(containing: locationInContainer)
     guard !scrollableChain.isEmpty else {
       // Outside a scrollable, the sheet owns any direction in which it has a
@@ -1557,6 +1558,20 @@ extension BottomSheetHostingView: UIGestureRecognizerDelegate {
       isVerticallyScrollable(scrollView)
     else {
       return false
+    }
+    return true
+  }
+
+  public func gestureRecognizer(
+    _ gestureRecognizer: UIGestureRecognizer,
+    shouldReceive touch: UITouch
+  ) -> Bool {
+    // Record the touch-down point before the pan's translation threshold is
+    // exceeded. gestureRecognizerShouldBegin and handlePan(.began) hit-test
+    // scrollables from this point instead of the post-threshold pan location,
+    // matching Android's ACTION_DOWN semantics.
+    if gestureRecognizer === panGesture, panGesture.numberOfTouches == 0 {
+      initialTouchLocation = touch.location(in: sheetContainer)
     }
     return true
   }


### PR DESCRIPTION
## Root cause

As analyzed in #63, the iOS checks that decide whether the sheet or a nested scrollable owns a pan gesture resolve the touched scroll view from `panGesture.location(in: sheetContainer)` — read inside `gestureRecognizerShouldBegin` and `handlePan(.began)`, i.e. after UIKit's pan translation threshold has already been exceeded. That is the finger's *current* location, not the touch-down point. When the draggable chrome above a scrollable is short (grabber strip, compact header), the threshold movement carries the point into the scrollable's frame before the check runs, so `scrollableAncestorChain(containing:)` resolves a scroll view the user never touched and the sheet refuses a drag aimed at the handle.

Android does not have this problem: `BottomSheetHostView.kt` records `initialTouchX`/`initialTouchY` at `ACTION_DOWN` and hit-tests scrollables from those stored coordinates.

## The fix

- Implement `gestureRecognizer(_:shouldReceive:)` on the pan's existing delegate and store the touch-down location (in `sheetContainer` coordinates) when the first touch arrives, before any translation threshold is involved.
- Use that stored point for the scrollable hit-test in `gestureRecognizerShouldBegin` and when resolving `activeScrollViewStates` in `handlePan(.began)`, with the previous `location(in:)` read kept as a fallback.

This mirrors the Android `ACTION_DOWN` semantics, so both platforms now negotiate scroll-vs-sheet ownership from where the finger actually landed.

## Verification

- Built the `ReactNativeBottomSheet` pod target for the iOS Simulator (`xcodebuild -workspace ReactNativeBottomSheetExample.xcworkspace -scheme ReactNativeBottomSheet -configuration Debug -destination "generic/platform=iOS Simulator"`) — BUILD SUCCEEDED.
- Built the full example app (`-scheme ReactNativeBottomSheetExample`, same destination) — BUILD SUCCEEDED.

Fixes #63