### PR TITLE
Add JSON-LD and llms.txt for AI search

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -56,6 +56,20 @@ jobs:
           DOCUSAURUS_BASE_URL: /react-native-bottom-sheet/
         run: bun run build
 
+      - name: Check docs llms.txt
+        working-directory: docs
+        run: |
+          file=build/llms.txt
+          if [ ! -s "$file" ]; then
+            echo "::error::$file is missing or empty"
+            exit 1
+          fi
+          count=$(grep -cE '^- \[[^]]+\]\(https://software-mansion-labs\.github\.io/react-native-bottom-sheet/[^)]+\)' "$file" || true)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::$file lists no pages"
+            exit 1
+          fi
+          echo "llms.txt lists $count pages"
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import swmGeo from './plugins/swm-geo.mjs';
 
 const config: Config = {
   title: 'React Native Bottom Sheet',
@@ -21,6 +22,9 @@ const config: Config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+
+  plugins: [swmGeo],
+
 
   presets: [
     [

--- a/docs/plugins/swm-geo.mjs
+++ b/docs/plugins/swm-geo.mjs
@@ -2,7 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const ORGANIZATION_ID = 'https://swmansion.com/#organization';
-const SECTIONS = { docs: 'Documentation', blog: 'Blog', examples: 'Examples' };
+// Section names come from the folder a page lives in. `docs` is the only
+// segment worth renaming - `blog` and `examples` already title-case to
+// themselves, so listing them bought nothing.
+const SECTION_NAMES = { docs: 'Documentation' };
 const ACRONYMS = { api: 'API', ui: 'UI' };
 
 const titleCase = (segment) =>
@@ -11,11 +14,9 @@ const titleCase = (segment) =>
     .map((word) => ACRONYMS[word] ?? word.replace(/^./, (c) => c.toUpperCase()))
     .join(' ');
 
-// With `routeBasePath: '/'` there is no `docs/` prefix to match, so group by
-// the folder the page lives in instead of dropping everything into `Pages`.
 const sectionOf = (relative) => {
   const parts = relative.split('/').filter(Boolean);
-  if (SECTIONS[parts[0]]) return SECTIONS[parts[0]];
+  if (SECTION_NAMES[parts[0]]) return SECTION_NAMES[parts[0]];
   if (parts.length < 2) return 'Pages';
   return titleCase(parts[0]);
 };
@@ -105,11 +106,11 @@ function buildLlmsTxt({ siteConfig, routesPaths, readPage }) {
   const lines = [`# ${title}`];
   if (tagline) lines.push('', `> ${tagline}`);
 
-  const preferred = ['Documentation', 'Examples', 'Blog'];
+  // Documentation first, the rest alphabetically, loose pages last.
   const order = [
-    ...preferred.filter((section) => grouped.has(section)),
+    ...(grouped.has('Documentation') ? ['Documentation'] : []),
     ...[...grouped.keys()]
-      .filter((section) => !preferred.includes(section) && section !== 'Pages')
+      .filter((section) => section !== 'Documentation' && section !== 'Pages')
       .sort(),
     ...(grouped.has('Pages') ? ['Pages'] : []),
   ];

--- a/docs/plugins/swm-geo.mjs
+++ b/docs/plugins/swm-geo.mjs
@@ -1,0 +1,140 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ORGANIZATION_ID = 'https://swmansion.com/#organization';
+const SECTIONS = { docs: 'Documentation', blog: 'Blog', examples: 'Examples' };
+
+const decode = (value) =>
+  value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#(?:39|x27);/g, "'")
+    .trim();
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const metaOf = (html, name) =>
+  new RegExp(
+    `<meta[^>]+name="${escapeRegExp(name)}"[^>]+content="([^"]*)"`,
+    'i',
+  ).exec(html)?.[1] ?? '';
+
+function describe(html, siteTitle) {
+  const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? '';
+  const title = decode(raw).replace(
+    new RegExp(`\\s*\\|\\s*${escapeRegExp(siteTitle)}$`),
+    '',
+  );
+  return { title, description: decode(metaOf(html, 'description')) };
+}
+
+// Same @id as swmansion.com, so engines read one company across both domains.
+function buildStructuredData(siteConfig) {
+  const { organizationName, projectName, tagline, title } = siteConfig;
+  const repository =
+    organizationName && projectName
+      ? `https://github.com/${organizationName}/${projectName}`
+      : undefined;
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': ORGANIZATION_ID,
+        name: 'Software Mansion',
+        url: 'https://swmansion.com',
+        sameAs: [
+          'https://github.com/software-mansion',
+          'https://www.linkedin.com/company/software-mansion/',
+          'https://twitter.com/swmansion',
+          'https://www.youtube.com/c/SoftwareMansion',
+        ],
+      },
+      {
+        '@type': 'SoftwareSourceCode',
+        name: title,
+        ...(tagline ? { description: tagline } : {}),
+        ...(repository ? { codeRepository: repository } : {}),
+        author: { '@id': ORGANIZATION_ID },
+        maintainer: { '@id': ORGANIZATION_ID },
+      },
+    ],
+  };
+}
+
+function buildLlmsTxt({ siteConfig, routesPaths, readPage }) {
+  const { baseUrl, title, tagline, url } = siteConfig;
+  const grouped = new Map();
+
+  for (const route of routesPaths) {
+    if (!route.startsWith(baseUrl) || route.endsWith('404.html')) continue;
+
+    const relative = route.slice(baseUrl.length);
+    const html = readPage(relative);
+    if (!html) continue;
+
+    const page = describe(html, title);
+    if (!page.title) continue;
+
+    const section = SECTIONS[relative.split('/')[0]] ?? 'Pages';
+    const line = `- [${page.title}](${url.replace(/\/$/, '')}${route})${page.description ? `: ${page.description}` : ''}`;
+
+    if (!grouped.has(section)) grouped.set(section, []);
+    grouped.get(section).push(line);
+  }
+
+  const lines = [`# ${title}`];
+  if (tagline) lines.push('', `> ${tagline}`);
+
+  for (const section of ['Documentation', 'Examples', 'Blog', 'Pages']) {
+    const entries = grouped.get(section);
+    if (!entries?.length) continue;
+    lines.push('', `## ${section}`, '', ...entries.sort());
+  }
+
+  lines.push(
+    '',
+    '## About',
+    '',
+    `- [Software Mansion](https://swmansion.com): maintainer of ${title}`,
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+export default function swmGeoPlugin(context) {
+  return {
+    name: 'swm-geo',
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'script',
+            attributes: { type: 'application/ld+json' },
+            innerHTML: JSON.stringify(buildStructuredData(context.siteConfig)),
+          },
+        ],
+      };
+    },
+
+    async postBuild({ siteConfig, routesPaths, outDir }) {
+      const readPage = (relative) => {
+        const file = path.join(outDir, relative, 'index.html');
+        return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+      };
+
+      await fs.promises.writeFile(
+        path.join(outDir, 'llms.txt'),
+        buildLlmsTxt({ siteConfig, routesPaths, readPage }),
+        'utf8',
+      );
+    },
+  };
+}
+
+export { buildLlmsTxt, buildStructuredData };

--- a/docs/plugins/swm-geo.mjs
+++ b/docs/plugins/swm-geo.mjs
@@ -2,9 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const ORGANIZATION_ID = 'https://swmansion.com/#organization';
-// Section names come from the folder a page lives in. `docs` is the only
-// segment worth renaming - `blog` and `examples` already title-case to
-// themselves, so listing them bought nothing.
 const SECTION_NAMES = { docs: 'Documentation' };
 const ACRONYMS = { api: 'API', ui: 'UI' };
 

--- a/docs/plugins/swm-geo.mjs
+++ b/docs/plugins/swm-geo.mjs
@@ -3,6 +3,22 @@ import path from 'node:path';
 
 const ORGANIZATION_ID = 'https://swmansion.com/#organization';
 const SECTIONS = { docs: 'Documentation', blog: 'Blog', examples: 'Examples' };
+const ACRONYMS = { api: 'API', ui: 'UI' };
+
+const titleCase = (segment) =>
+  segment
+    .split(/[-_]/)
+    .map((word) => ACRONYMS[word] ?? word.replace(/^./, (c) => c.toUpperCase()))
+    .join(' ');
+
+// With `routeBasePath: '/'` there is no `docs/` prefix to match, so group by
+// the folder the page lives in instead of dropping everything into `Pages`.
+const sectionOf = (relative) => {
+  const parts = relative.split('/').filter(Boolean);
+  if (SECTIONS[parts[0]]) return SECTIONS[parts[0]];
+  if (parts.length < 2) return 'Pages';
+  return titleCase(parts[0]);
+};
 
 const decode = (value) =>
   value
@@ -79,7 +95,7 @@ function buildLlmsTxt({ siteConfig, routesPaths, readPage }) {
     const page = describe(html, title);
     if (!page.title) continue;
 
-    const section = SECTIONS[relative.split('/')[0]] ?? 'Pages';
+    const section = sectionOf(relative);
     const line = `- [${page.title}](${url.replace(/\/$/, '')}${route})${page.description ? `: ${page.description}` : ''}`;
 
     if (!grouped.has(section)) grouped.set(section, []);
@@ -89,7 +105,16 @@ function buildLlmsTxt({ siteConfig, routesPaths, readPage }) {
   const lines = [`# ${title}`];
   if (tagline) lines.push('', `> ${tagline}`);
 
-  for (const section of ['Documentation', 'Examples', 'Blog', 'Pages']) {
+  const preferred = ['Documentation', 'Examples', 'Blog'];
+  const order = [
+    ...preferred.filter((section) => grouped.has(section)),
+    ...[...grouped.keys()]
+      .filter((section) => !preferred.includes(section) && section !== 'Pages')
+      .sort(),
+    ...(grouped.has('Pages') ? ['Pages'] : []),
+  ];
+
+  for (const section of order) {
     const entries = grouped.get(section);
     if (!entries?.length) continue;
     lines.push('', `## ${section}`, '', ...entries.sort());
@@ -116,7 +141,9 @@ export default function swmGeoPlugin(context) {
           {
             tagName: 'script',
             attributes: { type: 'application/ld+json' },
-            innerHTML: JSON.stringify(buildStructuredData(context.siteConfig)),
+            innerHTML: JSON.stringify(
+              buildStructuredData(context.siteConfig),
+            ).replace(/</g, '\\u003c'),
           },
         ],
       };

--- a/docs/plugins/swm-geo.mjs
+++ b/docs/plugins/swm-geo.mjs
@@ -2,8 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const ORGANIZATION_ID = 'https://swmansion.com/#organization';
-const SECTION_NAMES = { docs: 'Documentation' };
-const ACRONYMS = { api: 'API', ui: 'UI' };
+const ACRONYMS = { api: 'API', ui: 'UI', sdk: 'SDK', ios: 'iOS' };
 
 const titleCase = (segment) =>
   segment
@@ -12,10 +11,9 @@ const titleCase = (segment) =>
     .join(' ');
 
 const sectionOf = (relative) => {
-  const parts = relative.split('/').filter(Boolean);
-  if (SECTION_NAMES[parts[0]]) return SECTION_NAMES[parts[0]];
-  if (parts.length < 2) return 'Pages';
-  return titleCase(parts[0]);
+  const dir = relative.split('/').filter(Boolean).slice(0, -1);
+  if (dir[0] === 'docs') dir.shift();
+  return dir.length === 0 ? 'Documentation' : dir.map(titleCase).join(' / ');
 };
 
 const decode = (value) =>
@@ -103,13 +101,9 @@ function buildLlmsTxt({ siteConfig, routesPaths, readPage }) {
   const lines = [`# ${title}`];
   if (tagline) lines.push('', `> ${tagline}`);
 
-  // Documentation first, the rest alphabetically, loose pages last.
   const order = [
     ...(grouped.has('Documentation') ? ['Documentation'] : []),
-    ...[...grouped.keys()]
-      .filter((section) => section !== 'Documentation' && section !== 'Pages')
-      .sort(),
-    ...(grouped.has('Pages') ? ['Pages'] : []),
+    ...[...grouped.keys()].filter((s) => s !== 'Documentation').sort(),
   ];
 
   for (const section of order) {


### PR DESCRIPTION
Two SEO changes for the docs site. Nothing changes the rendered page.

- **JSON-LD**: `Organization` with the same `@id` as swmansion.com, plus `SoftwareSourceCode`, derived from `siteConfig`. The identical `@id` is what makes engines read these docs and swmansion.com as one company instead of two unrelated sites.
- **`llms.txt`**, generated on `postBuild` — no new dependency. The publish workflow fails if the file is missing or lists nothing.

Both come from `docs/plugins/swm-geo.mjs`, registered with one line. The same change is going out across the docs repos; reference: software-mansion/react-native-reanimated#10332.

**Worth knowing:** this site is served from `software-mansion-labs.github.io`, which has **no `robots.txt` at all** — the origin returns 404 for it, so there is no `Content-Signal` and no crawl policy for any of the 14 docs sites on it. Fixing that needs an org-level Pages repo (`software-mansion-labs/software-mansion-labs.github.io`), which does not exist. This PR is worth doing regardless, but it does not close that gap.