### PR TITLE
fix(android): pin the sheet's ancestor wrappers as real views (collapsable=false)

### DIFF
--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -262,8 +262,19 @@ export const BottomSheet = (props: BottomSheetProps) => {
     <View
       style={StyleSheet.absoluteFill}
       pointerEvents={modal ? (isSheetClosed ? 'none' : 'auto') : 'box-none'}
+      // Keep both ancestor wrappers real native views (Android): this outer
+      // one toggles pointerEvents ('none' <-> 'auto') on open/close, which is
+      // exactly the prop change that forces Fabric to unflatten it and emit
+      // the reparenting batch that can miss the Create mutation. The content
+      // views below the native view already pin collapsable={false}; the
+      // ancestors were the remaining flattenable gap. See issue #78.
+      collapsable={false}
     >
-      <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      <View
+        pointerEvents="box-none"
+        style={StyleSheet.absoluteFill}
+        collapsable={false}
+      >
         <NativeView
           pointerEvents="box-none"
           style={[

--- a/src/BottomSheetProvider.tsx
+++ b/src/BottomSheetProvider.tsx
@@ -29,7 +29,18 @@ const PortalHost = () => {
   );
 
   return portals.map(([key, element]) => (
-    <View key={key} style={StyleSheet.absoluteFill} pointerEvents="box-none">
+    <View
+      key={key}
+      style={StyleSheet.absoluteFill}
+      pointerEvents="box-none"
+      // Keep this wrapper a real native view (Android). As a layout-only view
+      // Fabric flattens it, and portal-entry churn (a sheet remounted while
+      // the previous instance tears down) makes the differ unflatten it
+      // mid-flight - a reparenting batch that can arrive without the
+      // wrapper's Create mutation, killing the surface with "Unable to find
+      // viewState for tag". See issue #78.
+      collapsable={false}
+    >
       {element}
     </View>
   ));


### PR DESCRIPTION
Fixes #78.

On Android with the New Architecture, the three layout-only wrappers above the native `BottomSheetView` are flattenable, and the outer sheet wrapper toggles `pointerEvents` ('none' <-> 'auto') on every open/close - forcing a flatten -> unflatten transition under portal-entry churn. That reparenting batch can arrive **without the wrapper's Create mutation** (an RN Fabric transaction/differ bug, reported separately to react/react-native), and a failing batch mount item kills the whole surface: `RetryableMountingLayerException: Unable to find viewState for tag`, white screen, dead touches. Full evidence (mount batch dumps, surface registry, causal chain) in #78.

`collapsable={false}` (a no-op on iOS) keeps the wrappers real from creation so the transition can never be emitted. The content views below the native view already pin `collapsable={false}`; this closes the same gap for the ancestors.

Verified on device (Galaxy S23 Ultra, RN 0.85.3, our production app): pre-fix the crash reproduced within ~3 rapid open/close cycles of an action sheet; pinning only the portal wrapper moved the identical crash exactly one level down to the outer sheet wrapper (causal confirmation); with all three pinned, 40 rapid-fire cycles produced zero occurrences. The crash had reached ~2% of Android sessions in production before the fix.