### PR TITLE
fix(android): ignore scrim taps once the sheet is closing

### DIFF
--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt
@@ -1188,7 +1188,9 @@ class BottomSheetHostView(context: Context) : ReactViewGroup(context), NestedScr
           scrimPressed = false
           scrimTouchActive = false
           activePointerId = MotionEvent.INVALID_POINTER_ID
-          if (shouldDismiss && closeIndex != null) {
+          // A close already targeting this detent owns the dismissal: restarting it
+          // would emit a second index change and drop the running spring's velocity.
+          if (shouldDismiss && closeIndex != null && closeIndex != targetIndex) {
             snapToIndex(closeIndex, 0f)
           }
           return true

--- a/android/src/test/java/com/swmansion/reactnativebottomsheet/BottomSheetViewScrimDismissTest.kt
+++ b/android/src/test/java/com/swmansion/reactnativebottomsheet/BottomSheetViewScrimDismissTest.kt
@@ -1,0 +1,124 @@
+package com.swmansion.reactnativebottomsheet
+
+import android.app.Activity
+import android.graphics.Color
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+// Dismissal is asserted through onIndexChange alone: the closing spring runs on a
+// Choreographer that Robolectric stops driving once another view test class has run.
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class BottomSheetViewScrimDismissTest {
+  private var nextTouchDownTime = 1_000L
+
+  @Before
+  fun useLocalReactNativeFeatureFlags() {
+    ReactNativeFeatureFlagsForTests.setUp()
+  }
+
+  @Test
+  fun `scrim tap dismisses an open sheet`() {
+    withOpenModalSheet { sheet, listener ->
+      tapScrim(sheet)
+
+      assertEquals(listOf(0), listener.indexChanges)
+    }
+  }
+
+  @Test
+  fun `further scrim taps during the close snap emit no extra index change`() {
+    withOpenModalSheet { sheet, listener ->
+      tapScrim(sheet)
+      tapScrim(sheet)
+      tapScrim(sheet)
+
+      assertEquals(listOf(0), listener.indexChanges)
+    }
+  }
+
+  private fun withOpenModalSheet(block: (BottomSheetView, RecordingBottomSheetListener) -> Unit) {
+    val controller = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    val activity = controller.get()
+    val listener = RecordingBottomSheetListener()
+    val sheet = openModalSheet(activity, listener)
+    try {
+      block(sheet, listener)
+    } finally {
+      sheet.destroy()
+      shadowOf(Looper.getMainLooper()).idle()
+      controller.close()
+    }
+  }
+
+  private fun openModalSheet(activity: Activity, listener: RecordingBottomSheetListener) =
+    BottomSheetView(activity)
+      .apply {
+        this.listener = listener
+        animateIn = false
+        modal = true
+        setScrimColor(Color.BLACK)
+        setScrimOpacities(listOf(0f, 1f))
+        setDetents(
+          listOf(
+            mapOf("value" to 0.0, "kind" to "points", "programmatic" to false),
+            mapOf("value" to 300.0, "kind" to "points", "programmatic" to false),
+          )
+        )
+        setIndex(1)
+      }
+      .also {
+        activity.setContentView(it)
+        layoutView(it)
+      }
+
+  /** Presses and releases above the sheet top, where the scrim is the touch target. */
+  private fun tapScrim(sheet: BottomSheetView) {
+    val downTime = nextTouchDownTime
+    nextTouchDownTime += 100L
+    val x = 10f
+    val y = 100f
+    val down = MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, x, y, 0)
+    val up = MotionEvent.obtain(downTime, downTime + 10, MotionEvent.ACTION_UP, x, y, 0)
+    sheet.dispatchTouchEvent(down)
+    sheet.dispatchTouchEvent(up)
+    down.recycle()
+    up.recycle()
+  }
+
+  private fun layoutView(view: View) {
+    val width = 1080
+    val height = 1920
+    view.measure(
+      View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+      View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY),
+    )
+    view.layout(0, 0, width, height)
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+}
+
+private class RecordingBottomSheetListener : BottomSheetViewListener {
+  val indexChanges = mutableListOf<Int>()
+
+  override fun onIndexChange(index: Int) {
+    indexChanges.add(index)
+  }
+
+  override fun onSettle(index: Int) = Unit
+
+  override fun onPositionChange(position: Double, index: Double) = Unit
+
+  override fun onCloseRequest() = Unit
+}


### PR DESCRIPTION
## Summary

On Android, tapping the scrim of a modal sheet that is already animating to
its closed detent starts the dismissal over again.

`onTouchEvent` snaps to `scrimDismissIndex` on every scrim release, without
checking whether that detent is already `targetIndex`:

https://github.com/software-mansion-labs/react-native-bottom-sheet/blob/249b2cf/android/src/main/java/com/swmansion/reactnativebottomsheet/BottomSheetHostView.kt#L1185-L1194

The scrim stays visible for the whole close animation: `updateScrim` only
forces it hidden once the sheet is settled at the closed detent
(`isTargetingClosedDetent && activeAnimation == null && !isPanning`), so
`isScrimVisible()` is still true mid-close and every further tap is treated
as a fresh dismissal. Each one calls `snapToIndex(closeIndex, 0f)`, which
emits `onIndexChange` and cancels the in-flight spring to start a new one
from zero velocity, so the sheet also loses the momentum it had.

iOS does not have this: `handleScrimPress` bails when the closed detent is
already the target.

https://github.com/software-mansion-labs/react-native-bottom-sheet/blob/249b2cf/ios/BottomSheetHostingView.swift#L717-L728

## Fix

Add the same `closeIndex != targetIndex` guard to the Android handler.
A settled closed sheet is unaffected, because its scrim is already hidden and
`shouldDismiss` is false there.

## Repro

Modal sheet with `detents={[0, 300]}`, `index={1}` and a scrim, tapping the
scrim three times in quick succession:

| | `onIndexChange` | `onSettle` |
| --- | --- | --- |
| before | `0`, `0`, `0` | `0` |
| after | `0` | `0` |

## Test plan

- New `android/src/test/.../BottomSheetViewScrimDismissTest.kt` covers both
  the single tap (still dismisses) and the repeated taps (one index change).
- Reverted the one-line guard and confirmed the repeated-tap test fails with
  `expected:<[0]> but was:<[0, 0, 0]>` while the single-tap test still passes,
  then restored it and confirmed the whole `test:android:unit` suite is green.
- `bun run lint`, `bun run typecheck`, `ktfmt --google-style`.
