### PR TITLE
fix(android): route native overlay Back through ReactActivity

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
       - run: bun run test:android:prepare
       - uses: gradle/actions/setup-gradle@v6
         with:
@@ -35,10 +35,13 @@ jobs:
       - run: bun run test:android:unit
       - run: bun run test:android:instrumented:assemble
   android-instrumented:
-    name: Android instrumented tests
+    name: Android instrumented tests (API ${{ matrix.api-level }})
     needs: check
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        api-level: [35, 36]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -64,7 +67,7 @@ jobs:
       - name: Run Android instrumented tests
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
-          api-level: 36
+          api-level: ${{ matrix.api-level }}
           arch: x86_64
           enable-hw-keyboard: true
           script: bun run test:android:instrumented

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,6 +72,13 @@ android {
   }
 }
 
+tasks.withType(org.gradle.api.tasks.testing.Test).configureEach {
+  // Robolectric requires Java 21 when a unit test targets Android API 36.
+  javaLauncher = javaToolchains.launcherFor {
+    languageVersion = org.gradle.jvm.toolchain.JavaLanguageVersion.of(21)
+  }
+}
+
 dependencies {
   implementation "com.facebook.react:react-android"
   // Minimum for predictive Back, including callback-addition and restarted-gesture fixes.

--- a/android/src/androidTest/AndroidManifest.xml
+++ b/android/src/androidTest/AndroidManifest.xml
@@ -4,5 +4,9 @@
       android:name="androidx.activity.ComponentActivity"
       android:exported="true"
       android:theme="@android:style/Theme.Material.Light.NoActionBar" />
+    <activity
+      android:name="com.swmansion.reactnativebottomsheet.RecordingReactActivity"
+      android:exported="true"
+      android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
   </application>
 </manifest>

--- a/android/src/androidTest/java/com/swmansion/reactnativebottomsheet/ReactActivityBackRoutingInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/swmansion/reactnativebottomsheet/ReactActivityBackRoutingInstrumentedTest.kt
@@ -1,0 +1,71 @@
+package com.swmansion.reactnativebottomsheet
+
+import android.view.KeyEvent
+import android.widget.FrameLayout
+import androidx.activity.ComponentDialog
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.swmansion.reactnativebottomsheet.closerequest.CloseRequestInputState
+import com.swmansion.reactnativebottomsheet.closerequest.OverlayCloseRequestController
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReactActivityBackRoutingInstrumentedTest {
+  @Test
+  fun nativeOverlayBackWithoutHandlerEntersReactNativeOnceAndLeavesDialogVisible() {
+    RecordingReactActivityDelegate.backEntryCount.set(0)
+    val closeRequestCount = AtomicInteger()
+    lateinit var controller: OverlayCloseRequestController
+    lateinit var dialog: ComponentDialog
+
+    ActivityScenario.launch(RecordingReactActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        controller = OverlayCloseRequestController {
+          closeRequestCount.incrementAndGet()
+          true
+        }
+        dialog =
+          ComponentDialog(activity).also {
+            it.setContentView(FrameLayout(activity))
+            it.show()
+          }
+        controller.bind(dialog)
+        controller.update(
+          CloseRequestInputState(
+            isAttached = true,
+            isLifecycleActive = true,
+            isModal = true,
+            hasCloseRequestHandler = false,
+            isPresentationActive = true,
+            isTargetResolvedAndOpen = true,
+          ),
+          usesOverlayDialog = true,
+          isSheetInteractive = true,
+        )
+      }
+
+      val instrumentation = InstrumentationRegistry.getInstrumentation()
+      instrumentation.waitForIdleSync()
+      instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_BACK)
+      instrumentation.waitForIdleSync()
+
+      assertEquals(1, RecordingReactActivityDelegate.backEntryCount.get())
+      assertEquals(0, closeRequestCount.get())
+      scenario.onActivity { activity ->
+        assertTrue(dialog.isShowing)
+        assertFalse(activity.isFinishing)
+      }
+
+      scenario.onActivity {
+        controller.dispose()
+        dialog.dismiss()
+      }
+    }
+  }
+}

--- a/android/src/androidTest/java/com/swmansion/reactnativebottomsheet/RecordingReactActivity.kt
+++ b/android/src/androidTest/java/com/swmansion/reactnativebottomsheet/RecordingReactActivity.kt
@@ -1,0 +1,42 @@
+package com.swmansion.reactnativebottomsheet
+
+import android.os.Bundle
+import android.view.KeyEvent
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import java.util.concurrent.atomic.AtomicInteger
+
+class RecordingReactActivity : ReactActivity() {
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    RecordingReactActivityDelegate(this)
+}
+
+class RecordingReactActivityDelegate(activity: ReactActivity) :
+  ReactActivityDelegate(activity, null) {
+  override fun onCreate(savedInstanceState: Bundle?) = Unit
+
+  override fun onPause() = Unit
+
+  override fun onResume() = Unit
+
+  override fun onDestroy() = Unit
+
+  override fun onWindowFocusChanged(hasFocus: Boolean) = Unit
+
+  override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean = false
+
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean = false
+
+  override fun onKeyLongPress(keyCode: Int, event: KeyEvent): Boolean = false
+
+  override fun onUserLeaveHint() = Unit
+
+  override fun onBackPressed(): Boolean {
+    backEntryCount.incrementAndGet()
+    return true
+  }
+
+  companion object {
+    val backEntryCount = AtomicInteger()
+  }
+}

--- a/android/src/main/java/com/swmansion/reactnativebottomsheet/closerequest/OverlayCloseRequestController.kt
+++ b/android/src/main/java/com/swmansion/reactnativebottomsheet/closerequest/OverlayCloseRequestController.kt
@@ -6,6 +6,7 @@ import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.ComponentDialog
 import androidx.lifecycle.Lifecycle
+import com.facebook.react.ReactActivity
 
 /**
  * Atomically computes overlay-dialog Back/Escape routing, touchability, focusability, and alpha
@@ -119,10 +120,20 @@ internal class OverlayCloseRequestController(private val emitCloseRequest: () ->
     when (action) {
       CloseRequestInputAction.EMIT_CLOSE_REQUEST -> emitCloseRequestIfEligible()
       CloseRequestInputAction.CONSUME -> Unit
-      CloseRequestInputAction.PASS_THROUGH ->
-        (dialog?.context?.findActivity() as? ComponentActivity)
-          ?.onBackPressedDispatcher
-          ?.onBackPressed()
+      CloseRequestInputAction.PASS_THROUGH -> routeHostBack()
+    }
+  }
+
+  private fun routeHostBack() {
+    when (val activity = dialog?.context?.findActivity()) {
+      is ReactActivity -> {
+        // ReactActivity keeps this deprecated override as its Back entry point across the supported
+        // RN range. Calling the Activity dispatcher directly skips React Native on versions or
+        // configurations where RN does not register its own dispatcher callback. Newer RN
+        // callbacks route to this same method.
+        @Suppress("DEPRECATION") activity.onBackPressed()
+      }
+      is ComponentActivity -> activity.onBackPressedDispatcher.onBackPressed()
     }
   }
 

--- a/android/src/test/java/com/swmansion/reactnativebottomsheet/closerequest/OverlayCloseRequestControllerTest.kt
+++ b/android/src/test/java/com/swmansion/reactnativebottomsheet/closerequest/OverlayCloseRequestControllerTest.kt
@@ -9,6 +9,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -170,6 +172,67 @@ class OverlayCloseRequestControllerTest {
     }
   }
 
+  @Test
+  @Config(sdk = [35, 36])
+  fun `Host Back enters consuming React Native once without dismissing the dialog`() {
+    RecordingReactActivityDelegate.backEntryCount = 0
+    withAppCompatActivity<RecordingReactActivity> { activity ->
+      var closeRequestCount = 0
+      val controller = OverlayCloseRequestController {
+        closeRequestCount++
+        true
+      }
+      val dialog = shownDialog(activity)
+      controller.bind(dialog)
+      controller.update(
+        inputState(hasCloseRequestHandler = false),
+        usesOverlayDialog = true,
+        isSheetInteractive = false,
+      )
+
+      dialog.onBackPressedDispatcher.onBackPressed()
+
+      assertEquals(1, RecordingReactActivityDelegate.backEntryCount)
+      assertEquals(0, closeRequestCount)
+      assertTrue(dialog.isShowing)
+      assertFalse(activity.isFinishing)
+      controller.dispose()
+      dialog.dismiss()
+    }
+  }
+
+  @Test
+  @Config(sdk = [36])
+  fun `Host Back lets React Native default Back reach the native callback once on API 36`() {
+    DefaultBackRecordingReactActivityDelegate.backEntryCount = 0
+    withAppCompatActivity<DefaultBackRecordingReactActivity> { activity ->
+      var closeRequestCount = 0
+      var nativeBackCount = 0
+      activity.onBackPressedDispatcher.addCallback(countingCallback { nativeBackCount++ })
+      val controller = OverlayCloseRequestController {
+        closeRequestCount++
+        true
+      }
+      val dialog = shownDialog(activity)
+      controller.bind(dialog)
+      controller.update(
+        inputState(hasCloseRequestHandler = false),
+        usesOverlayDialog = true,
+        isSheetInteractive = false,
+      )
+
+      dialog.onBackPressedDispatcher.onBackPressed()
+
+      assertEquals(1, DefaultBackRecordingReactActivityDelegate.backEntryCount)
+      assertEquals(1, nativeBackCount)
+      assertEquals(0, closeRequestCount)
+      assertTrue(dialog.isShowing)
+      assertFalse(activity.isFinishing)
+      controller.dispose()
+      dialog.dismiss()
+    }
+  }
+
   private fun shownDialog(activity: ComponentActivity): ComponentDialog =
     ComponentDialog(activity).also { dialog ->
       dialog.setContentView(FrameLayout(activity))
@@ -217,5 +280,70 @@ class OverlayCloseRequestControllerTest {
     } finally {
       activityController.close()
     }
+  }
+
+  private inline fun <reified T : Activity> withAppCompatActivity(block: (T) -> Unit) {
+    val activityController =
+      Robolectric.buildActivity(T::class.java)
+        .also {
+          it.get().setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        }
+        .setup()
+    try {
+      block(activityController.get())
+    } finally {
+      activityController.close()
+    }
+  }
+}
+
+private class RecordingReactActivity : ReactActivity() {
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    RecordingReactActivityDelegate(this)
+}
+
+private class RecordingReactActivityDelegate(activity: ReactActivity) :
+  ReactActivityDelegate(activity, null) {
+  override fun onCreate(savedInstanceState: android.os.Bundle?) = Unit
+
+  override fun onPause() = Unit
+
+  override fun onResume() = Unit
+
+  override fun onDestroy() = Unit
+
+  override fun onBackPressed(): Boolean {
+    backEntryCount++
+    return true
+  }
+
+  companion object {
+    var backEntryCount = 0
+  }
+}
+
+private class DefaultBackRecordingReactActivity : ReactActivity() {
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    DefaultBackRecordingReactActivityDelegate(this)
+}
+
+private class DefaultBackRecordingReactActivityDelegate(private val activity: ReactActivity) :
+  ReactActivityDelegate(activity, null) {
+  override fun onCreate(savedInstanceState: android.os.Bundle?) = Unit
+
+  override fun onPause() = Unit
+
+  override fun onResume() = Unit
+
+  override fun onDestroy() = Unit
+
+  override fun onBackPressed(): Boolean {
+    backEntryCount++
+    activity.invokeDefaultOnBackPressed()
+    return true
+  }
+
+  companion object {
+    var backEntryCount = 0
   }
 }


### PR DESCRIPTION
Fixes #60.

nativeOverlay forwarded Back directly to the Activity's Back dispatcher. When React Native had no callback registered with that dispatcher, notably on Android 15 and earlier, this bypassed React Native's BackHandler. As a result, Back could return the user to the home screen without invoking their JS handler.

When an overlay delegates Back to the application, this change calls ReactActivity.onBackPressed() if the containing Activity extends ReactActivity. ReactActivity still uses onBackPressed() as its React Native Back entry point; its dispatcher callback, when registered, delegates to the same method. For other ComponentActivity implementations, forwarding through the Activity's Back dispatcher is preserved.

Close-request ownership and controlled sheet state remain unchanged.

### Test coverage

Adds Robolectric coverage for routing Back to ReactActivity on API 35 and 36, including forwarding through invokeDefaultOnBackPressed() to a native Activity callback on API 36.

An instrumentation test sends KEYCODE_BACK to a real dialog and verifies that Back reaches a recording ReactActivityDelegate exactly once, leaving the dialog visible when consumed. These tests verify native routing; they do not run a JavaScript BackHandler or exercise predictive Back gestures.

CI runs instrumentation on both APIs. JVM tests use Java 21 because Robolectric requires it for API 36.

### Known upstream limitation

On API 35, enabling predictive Back can independently prevent React Native from delivering `hardwareBackPress` to JS: https://github.com/react/react-native/issues/58407.

That issue reproduces without bottom sheets and can affect portal presentations relying on JS `BackHandler`, as well as screens with no active sheet. This PR fixes Back forwarding from native overlay dialogs; it does not change the Activity's own handling of system Back or the example's predictive Back configuration.